### PR TITLE
Add checkSubcomponents to equals() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SNAC Server
 
+[![Gitter](https://badges.gitter.im/snac-cooperative/snac.svg)](https://gitter.im/snac-cooperative/snac?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 This repository contains the entirety of the SNAC Server code, including all components written by the UVA development team.
 
 The [Testing Install](INSTALL_TEST.md) file includes instructions for how to install the server locally for testing purposes.

--- a/src/snac/client/openrefine/OpenRefine.php
+++ b/src/snac/client/openrefine/OpenRefine.php
@@ -106,7 +106,7 @@ class OpenRefine implements \snac\interfaces\ServerInterface {
                     // build the CSV line to print
                     $output = array(
                         "name" => $result["identity"]["nameEntries"][0]["original"],
-                        "id" => $result["identity"]["id"],
+                        "id" => $result["identity"]["ark"],
                         "type" => [ 
                             $result["identity"]["entityType"]["term"] 
                         ],
@@ -155,7 +155,7 @@ class OpenRefine implements \snac\interfaces\ServerInterface {
                         // build the results line
                         $output = array(
                             "name" => $result["identity"]["nameEntries"][0]["original"],
-                            "id" => $result["identity"]["id"],
+                            "id" => $result["identity"]["ark"],
                             "type" => [$result["identity"]["entityType"]["term"]],
                             "score" => round($result["strength"], 2),
                             "match" => ($result["strength"] > 11 ? true : false)
@@ -180,7 +180,7 @@ class OpenRefine implements \snac\interfaces\ServerInterface {
                     ]
                 ],
                 "view" => [
-                    "url" => \snac\Config::$WEBUI_URL . "/view/{{id}}"
+                    "url" => "{{id}}"
                 ],
                 "identifierSpace" => \snac\Config::$WEBUI_URL,
                 "name" => "SNAC Reconciliation for OpenRefine",

--- a/src/snac/client/rest/commands.json
+++ b/src/snac/client/rest/commands.json
@@ -157,6 +157,14 @@
         "returns" : [
         ]
     },
+    "constellation_add_maybesame" : {
+        "title" : "Add Maybe-Same Constellation Assertions",
+        "description" : "Makes a maybe-same assertion between the constellations specified.",
+        "parameters" : [
+        ],
+        "returns" : [
+        ]
+    },
     "constellation_diff" : {
         "title" : "Compute Constellation Diff",
         "description" : "Computes the difference between the two given Constellations.  Returns Constellation objects containing: only those items in the first, only those items in the second, and components shared.",

--- a/src/snac/client/webui/templates/date_entry.html
+++ b/src/snac/client/webui/templates/date_entry.html
@@ -3,7 +3,7 @@
 <div class="panel panel-default" id="{{short}}_panel_{{i}}">
 	<div class="panel-heading">{{ name }} - {{ X.singleDate.display }}</div>
 	<div class="panel-body">
-		<div class="col-xs-10" id="{{short}}_datapart_{{i}}">
+		<div class="col-sm-10" id="{{short}}_datapart_{{i}}">
             <input type="hidden" id="{{short}}_id_{{i}}" name="{{short}}_id_{{i}}" value="{{snacDate.id}}"/>
             <input id="{{short}}_version_{{i}}" name="{{short}}_version_{{i}}" type="hidden" value="{{ snacDate.version }}"/>
             <input id="{{short}}_operation_{{i}}" name="{{short}}_operation_{{i}}" type="hidden" value=""/>
@@ -102,7 +102,7 @@
 <div class="panel panel-default" id="{{short}}_panel_{{i}}">
 	<div class="panel-heading">{{ name }} - {{ X.dateRange.display }}</div>
 	<div class="panel-body">
-		<div class="col-xs-10" id="{{short}}_datapart_{{i}}">
+		<div class="col-sm-10" id="{{short}}_datapart_{{i}}">
             <input type="hidden" id="{{short}}_id_{{i}}" name="{{short}}_id_{{i}}" value="{{snacDate.id}}"/>
             <input id="{{short}}_version_{{i}}" name="{{short}}_version_{{i}}" type="hidden" value="{{ snacDate.version }}"/>
             <input id="{{short}}_operation_{{i}}" name="{{short}}_operation_{{i}}" type="hidden" value=""/>

--- a/src/snac/data/AbstractData.php
+++ b/src/snac/data/AbstractData.php
@@ -217,10 +217,9 @@ abstract class AbstractData implements \Serializable {
      * @param \snac\data\AbstractData[] $first first array
      * @param \snac\data\AbstractData[] $second second array
      * @param boolean $strict optional whether or not to check ID/Version/Operation
-     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return mixed[] An associative array of AbstractData[] with "intersection," "first," and "second" keys
      */
-    protected function diffArray($first, $second, $strict = true, $checkSubcomponents = true) {
+    protected function diffArray($first, $second, $strict = true) {
         $return = array(
             "intersection" => array(),
             "first" => array(),
@@ -242,7 +241,7 @@ abstract class AbstractData implements \Serializable {
         foreach ($first as $data) {
             $seen = false;
             foreach ($second as $k => $odata) {
-                if ($data != null && $data->equals($odata, $strict, $checkSubcomponents)
+                if ($data != null && $data->equals($odata, $strict)
                         && !isset($tmp[$k])) {
                     // in case there are duplicates in first
                     $tmp[$k] = true;

--- a/src/snac/data/AbstractData.php
+++ b/src/snac/data/AbstractData.php
@@ -158,10 +158,8 @@ abstract class AbstractData implements \Serializable {
                 return false;
         }
 
-        if ($checkSubcomponents) {
-            if (!$this->checkArrayEqual($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict, $checkSubcomponents))
-                return false;
-        }
+        if ($checkSubcomponents && !$this->checkArrayEqual($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict, $checkSubcomponents))
+            return false;
 
         // If all the tests pass, they are equal
         return true;

--- a/src/snac/data/AbstractData.php
+++ b/src/snac/data/AbstractData.php
@@ -130,10 +130,10 @@ abstract class AbstractData implements \Serializable {
      *
      * @param \snac\data\AbstractData $other The other object to compare
      * @param boolean $strict optional Whether to disable strict checking (skip id)
-     *
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true if equal, false if not
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || !($other instanceOf \snac\data\AbstractData))
             return false;
@@ -154,12 +154,14 @@ abstract class AbstractData implements \Serializable {
         if ($this->getMaxDateCount() > 0) {
             $tmp = array();
 
-            if (!$this->checkArrayEqual($this->getDateList(), $other->getDateList(), $strict))
+            if (!$this->checkArrayEqual($this->getDateList(), $other->getDateList(), $strict, $checkSubcomponents))
                 return false;
         }
 
-        if (!$this->checkArrayEqual($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict))
-            return false;
+        if ($checkSubcomponents) {
+            if (!$this->checkArrayEqual($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict, $checkSubcomponents))
+                return false;
+        }
 
         // If all the tests pass, they are equal
         return true;
@@ -174,9 +176,10 @@ abstract class AbstractData implements \Serializable {
      * @param \snac\data\AbstractData[] $first first array
      * @param \snac\data\AbstractData[] $second second array
      * @param boolean $strict optional whether or not to check ID/Version/Operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true if equal, false otherwise
      */
-    protected function checkArrayEqual($first, $second, $strict = true) {
+    protected function checkArrayEqual($first, $second, $strict = true, $checkSubcomponents = true) {
         if ($first == null && $second == null)
             return true;
         if ($first == null || $second == null)
@@ -188,7 +191,7 @@ abstract class AbstractData implements \Serializable {
 
         foreach ($first as $data) {
             foreach ($second as $k => $odata) {
-                if ((($data == null && $odata == null) || ($data != null && $data->equals($odata, $strict)))
+                if ((($data == null && $odata == null) || ($data != null && $data->equals($odata, $strict, $checkSubcomponents)))
                         && !isset($tmp[$k])) {
                     $tmp[$k] = true;
                 }
@@ -216,9 +219,10 @@ abstract class AbstractData implements \Serializable {
      * @param \snac\data\AbstractData[] $first first array
      * @param \snac\data\AbstractData[] $second second array
      * @param boolean $strict optional whether or not to check ID/Version/Operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return mixed[] An associative array of AbstractData[] with "intersection," "first," and "second" keys
      */
-    protected function diffArray($first, $second, $strict = true) {
+    protected function diffArray($first, $second, $strict = true, $checkSubcomponents = true) {
         $return = array(
             "intersection" => array(),
             "first" => array(),
@@ -240,7 +244,7 @@ abstract class AbstractData implements \Serializable {
         foreach ($first as $data) {
             $seen = false;
             foreach ($second as $k => $odata) {
-                if ($data != null && $data->equals($odata, $strict)
+                if ($data != null && $data->equals($odata, $strict, $checkSubcomponents)
                         && !isset($tmp[$k])) {
                     // in case there are duplicates in first
                     $tmp[$k] = true;

--- a/src/snac/data/AbstractOrderedComponent.php
+++ b/src/snac/data/AbstractOrderedComponent.php
@@ -24,7 +24,7 @@ abstract class AbstractOrderedComponent extends AbstractData {
 
     /**
      * @var string $dataType The data type of this object.
-     * 
+     *
      * This should be overwritten by any inheriting/child class
      */
     protected $dataType;
@@ -50,7 +50,7 @@ abstract class AbstractOrderedComponent extends AbstractData {
      *
      * @param string[] $data A list of data suitable for fromArray(). This exists for use by internal code to
      * send objects around the system, not for generally creating a new object.
-     * 
+     *
      */
     public function __construct($data = null) {
         parent::__construct($data);
@@ -67,7 +67,7 @@ abstract class AbstractOrderedComponent extends AbstractData {
     {
         return $this->dataType;
     }
-    
+
     /**
      * Set the data type for this object
      *
@@ -91,7 +91,7 @@ abstract class AbstractOrderedComponent extends AbstractData {
     /**
      * Get Component Type
      *
-     * Get type of this component, i.e. what it part it is 
+     * Get type of this component, i.e. what it part it is
      *
      * @return \snac\data\Term The part this component describes
      */
@@ -124,9 +124,9 @@ abstract class AbstractOrderedComponent extends AbstractData {
     /**
      * Set Component Type
      *
-     * Set the type of component 
+     * Set the type of component
      *
-     * @param \snac\data\Term $type The type of component 
+     * @param \snac\data\Term $type The type of component
      */
     public function setType($type) {
         $this->type = $type;
@@ -144,8 +144,8 @@ abstract class AbstractOrderedComponent extends AbstractData {
     }
 
     /**
-     * Returns this object's data as an associative array. 
-     * 
+     * Returns this object's data as an associative array.
+     *
      * @param boolean $shorten optional Whether or not to include null/empty components
      * @return string[][] This objects data in array form
      */
@@ -156,7 +156,7 @@ abstract class AbstractOrderedComponent extends AbstractData {
             "order" => $this->order,
             "type" => $this->type == null ? null : $this->type->toArray($shorten),
         );
-        
+
         $return = array_merge($return, parent::toArray($shorten));
 
         // Shorten if necessary
@@ -180,9 +180,9 @@ abstract class AbstractOrderedComponent extends AbstractData {
     public function fromArray($data) {
         if (!isset($data["dataType"]) || $data["dataType"] != $this->dataType)
             return false;
-       
+
         parent::fromArray($data);
-            
+
         if (isset($data["text"]))
             $this->text = $data["text"];
         else
@@ -192,9 +192,9 @@ abstract class AbstractOrderedComponent extends AbstractData {
             $this->order = $data["order"];
         else
             $this->order = null;
-        
-                
-        if (isset($data["type"]) && $data["type"] != null) 
+
+
+        if (isset($data["type"]) && $data["type"] != null)
             $this->type = new Term($data["type"]);
         else
             $this->type = null;
@@ -209,30 +209,30 @@ abstract class AbstractOrderedComponent extends AbstractData {
      *
      * @param \snac\data\AbstractOrderedComponent $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
-     *       
+     *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || !($other instanceof \snac\data\AbstractOrderedComponent))
             return false;
-        
+
         if ($other->getDataType() != $this->getDataType())
             return false;
-        
-        if (! parent::equals($other, $strict))
+
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
-        
+
         if ($this->getText() != $other->getText())
             return false;
         if ($this->getOrder() != $other->getOrder())
             return false;
-        
-        if (($this->getType() != null && ! $this->getType()->equals($other->getType(), $strict)) ||
+
+        if (($this->getType() != null && ! $this->getType()->equals($other->getType(), $strict, $checkSubcomponents)) ||
                  ($this->getType() == null && $other->getType() != null))
             return false;
         return true;
     }
 }
-

--- a/src/snac/data/AbstractTermData.php
+++ b/src/snac/data/AbstractTermData.php
@@ -149,10 +149,11 @@ abstract class AbstractTermData extends AbstractData {
      *
      * @param \snac\data\AbstractTermData $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
 
         if ($other == null || !($other instanceof \snac\data\AbstractTermData))
@@ -162,7 +163,7 @@ abstract class AbstractTermData extends AbstractData {
         if ($other->getDataType() != $this->getDataType())
             return false;
 
-        if (!parent::equals($other, $strict))
+        if (!parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if (($this->getTerm() != null && !$this->getTerm()->equals($other->getTerm())) ||

--- a/src/snac/data/AbstractTextData.php
+++ b/src/snac/data/AbstractTextData.php
@@ -130,16 +130,17 @@ abstract class AbstractTextData extends AbstractData{
      *
      * @param \snac\data\AbstractTextData $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\AbstractTextData))
             return false;
 
-        if (!parent::equals($other, $strict))
+        if (!parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getText() != $other->getText())

--- a/src/snac/data/BiogHist.php
+++ b/src/snac/data/BiogHist.php
@@ -186,22 +186,23 @@ class BiogHist extends AbstractData {
      *
      * @param \snac\data\BiogHist $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || !($other instanceof \snac\data\BiogHist))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getText() != $other->getText())
             return false;
 
-        if (($this->getLanguage() != null && !$this->getLanguage()->equals($other->getLanguage(), $strict)) ||
+        if (($this->getLanguage() != null && !$this->getLanguage()->equals($other->getLanguage(), $strict, $checkSubcomponents)) ||
                 ($this->getLanguage() == null && $other->getLanguage() != null))
             return false;
 

--- a/src/snac/data/Constellation.php
+++ b/src/snac/data/Constellation.php
@@ -539,7 +539,7 @@ class Constellation extends AbstractData {
                 $id = $i;
             }
         }
-        
+
         return $this->nameEntries[$id];
     }
 
@@ -1494,16 +1494,17 @@ class Constellation extends AbstractData {
      *
      * @param \snac\data\Constellation $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Constellation))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getArk() != $other->getArk())
@@ -1517,52 +1518,52 @@ class Constellation extends AbstractData {
          * Currently, we are not checking the maintenance events or images for equality
         *    if ($this->getMaintenanceAgency() != $other->getMaintenanceAgency())
         *        return false;
-        *    if (($this->getMaintenanceStatus() != null && ! $this->getMaintenanceStatus()->equals($other->getMaintenanceStatus(), $strict)) ||
+        *    if (($this->getMaintenanceStatus() != null && ! $this->getMaintenanceStatus()->equals($other->getMaintenanceStatus(), $strict, $checkSubcomponents)) ||
         *         ($this->getMaintenanceStatus() == null && $other->getMaintenanceStatus() != null))
         *        return false;
-        *    if (!$this->checkArrayEqual($this->getMaintenanceEvents(), $other->getMaintenanceEvents(), $strict))
+        *    if (!$this->checkArrayEqual($this->getMaintenanceEvents(), $other->getMaintenanceEvents(), $strict, $checkSubcomponents))
         *        return false;
-        *    if (!$this->checkArrayEqual($this->getImages(), $other->getImages(), $strict))
+        *    if (!$this->checkArrayEqual($this->getImages(), $other->getImages(), $strict, $checkSubcomponents))
         *        return false;
         **/
 
-        if (!$this->checkArrayEqual($this->getOtherRecordIDs(), $other->getOtherRecordIDs(), $strict))
+        if (!$this->checkArrayEqual($this->getOtherRecordIDs(), $other->getOtherRecordIDs(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getEntityIDs(), $other->getEntityIDs(), $strict))
+        if (!$this->checkArrayEqual($this->getEntityIDs(), $other->getEntityIDs(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getSources(), $other->getSources(), $strict))
+        if (!$this->checkArrayEqual($this->getSources(), $other->getSources(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getLegalStatuses(), $other->getLegalStatuses(), $strict))
+        if (!$this->checkArrayEqual($this->getLegalStatuses(), $other->getLegalStatuses(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getConventionDeclarations(), $other->getConventionDeclarations(), $strict))
+        if (!$this->checkArrayEqual($this->getConventionDeclarations(), $other->getConventionDeclarations(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getLanguagesUsed(), $other->getLanguagesUsed(), $strict))
+        if (!$this->checkArrayEqual($this->getLanguagesUsed(), $other->getLanguagesUsed(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getNameEntries(), $other->getNameEntries(), $strict))
+        if (!$this->checkArrayEqual($this->getNameEntries(), $other->getNameEntries(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getOccupations(), $other->getOccupations(), $strict))
+        if (!$this->checkArrayEqual($this->getOccupations(), $other->getOccupations(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getBiogHistList(), $other->getBiogHistList(), $strict))
+        if (!$this->checkArrayEqual($this->getBiogHistList(), $other->getBiogHistList(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getRelations(), $other->getRelations(), $strict))
+        if (!$this->checkArrayEqual($this->getRelations(), $other->getRelations(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getResourceRelations(), $other->getResourceRelations(), $strict))
+        if (!$this->checkArrayEqual($this->getResourceRelations(), $other->getResourceRelations(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getFunctions(), $other->getFunctions(), $strict))
+        if (!$this->checkArrayEqual($this->getFunctions(), $other->getFunctions(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getPlaces(), $other->getPlaces(), $strict))
+        if (!$this->checkArrayEqual($this->getPlaces(), $other->getPlaces(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getSubjects(), $other->getSubjects(), $strict))
+        if (!$this->checkArrayEqual($this->getSubjects(), $other->getSubjects(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getNationalities(), $other->getNationalities(), $strict))
+        if (!$this->checkArrayEqual($this->getNationalities(), $other->getNationalities(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getGenders(), $other->getGenders(), $strict))
+        if (!$this->checkArrayEqual($this->getGenders(), $other->getGenders(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getGeneralContexts(), $other->getGeneralContexts(), $strict))
+        if (!$this->checkArrayEqual($this->getGeneralContexts(), $other->getGeneralContexts(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getStructureOrGenealogies(), $other->getStructureOrGenealogies(), $strict))
+        if (!$this->checkArrayEqual($this->getStructureOrGenealogies(), $other->getStructureOrGenealogies(), $strict, $checkSubcomponents))
             return false;
-        if (!$this->checkArrayEqual($this->getMandates(), $other->getMandates(), $strict))
+        if (!$this->checkArrayEqual($this->getMandates(), $other->getMandates(), $strict, $checkSubcomponents))
             return false;
 
         return true;
@@ -1659,7 +1660,7 @@ class Constellation extends AbstractData {
             $element->collateSCMCitationsBySource($sources);
 
 
-        return $sources; 
+        return $sources;
     }
 
     /**
@@ -1748,9 +1749,10 @@ class Constellation extends AbstractData {
      *
      * @param  \snac\data\Constellation $other Constellation object to diff
      * @param boolean $strict optional If true, will check IDs and Versions.  Else (default) only checks data
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return \snac\data\Constellation[] Associative array of "intersection," "this," and "other" Constellations.
      */
-    public function diff($other, $strict = false) {
+    public function diff($other, $strict = false, $checkSubcomponents = false) {
         $return = array (
             "intersection" => null,
             "this" => null,
@@ -1771,115 +1773,115 @@ class Constellation extends AbstractData {
             $intersection->setArkID($this->getArk());
         }
 
-        if ($this->getEntityType() != null && $this->getEntityType()->equals($other->getEntityType(), $strict)) {
+        if ($this->getEntityType() != null && $this->getEntityType()->equals($other->getEntityType(), $strict, $checkSubcomponents)) {
             $intersection->setEntityType($this->getEntityType());
         }
 
-        $result = $this->diffArray($this->getOtherRecordIDs(), $other->getOtherRecordIDs(), $strict);
+        $result = $this->diffArray($this->getOtherRecordIDs(), $other->getOtherRecordIDs(), $strict, $checkSubcomponents);
         $intersection->otherRecordIDs = $result["intersection"];
         $first->otherRecordIDs = $result["first"];
         $second->otherRecordIDs = $result["second"];
 
-        $result = $this->diffArray($this->getEntityIDs(), $other->getEntityIDs(), $strict);
+        $result = $this->diffArray($this->getEntityIDs(), $other->getEntityIDs(), $strict, $checkSubcomponents);
         $intersection->entityIDs = $result["intersection"];
         $first->entityIDs = $result["first"];
         $second->entityIDs = $result["second"];
 
-        $result = $this->diffArray($this->getSources(), $other->getSources(), $strict);
+        $result = $this->diffArray($this->getSources(), $other->getSources(), $strict, $checkSubcomponents);
         $intersection->sources = $result["intersection"];
         $first->sources = $result["first"];
         $second->sources = $result["second"];
 
-        $result = $this->diffArray($this->getLegalStatuses(), $other->getLegalStatuses(), $strict);
+        $result = $this->diffArray($this->getLegalStatuses(), $other->getLegalStatuses(), $strict, $checkSubcomponents);
         $intersection->legalStatuses = $result["intersection"];
         $first->legalStatuses = $result["first"];
         $second->legalStatuses = $result["second"];
 
-        $result = $this->diffArray($this->getConventionDeclarations(), $other->getConventionDeclarations(), $strict);
+        $result = $this->diffArray($this->getConventionDeclarations(), $other->getConventionDeclarations(), $strict, $checkSubcomponents);
         $intersection->conventionDeclarations = $result["intersection"];
         $first->conventionDeclarations = $result["first"];
         $second->conventionDeclarations = $result["second"];
 
-        $result = $this->diffArray($this->getLanguagesUsed(), $other->getLanguagesUsed(), $strict);
+        $result = $this->diffArray($this->getLanguagesUsed(), $other->getLanguagesUsed(), $strict, $checkSubcomponents);
         $intersection->languagesUsed = $result["intersection"];
         $first->languagesUsed = $result["first"];
         $second->languagesUsed = $result["second"];
 
-        $result = $this->diffArray($this->getNameEntries(), $other->getNameEntries(), $strict);
+        $result = $this->diffArray($this->getNameEntries(), $other->getNameEntries(), $strict, $checkSubcomponents);
         $intersection->nameEntries = $result["intersection"];
         $first->nameEntries = $result["first"];
         $second->nameEntries = $result["second"];
 
-        $result = $this->diffArray($this->getOccupations(), $other->getOccupations(), $strict);
+        $result = $this->diffArray($this->getOccupations(), $other->getOccupations(), $strict, $checkSubcomponents);
         $intersection->occupations = $result["intersection"];
         $first->occupations = $result["first"];
         $second->occupations = $result["second"];
 
-        $result = $this->diffArray($this->getBiogHistList(), $other->getBiogHistList(), $strict);
+        $result = $this->diffArray($this->getBiogHistList(), $other->getBiogHistList(), $strict, $checkSubcomponents);
         $intersection->biogHists = $result["intersection"];
         $first->biogHists = $result["first"];
         $second->biogHists = $result["second"];
 
-        $result = $this->diffArray($this->getRelations(), $other->getRelations(), $strict);
+        $result = $this->diffArray($this->getRelations(), $other->getRelations(), $strict, $checkSubcomponents);
         $intersection->relations = $result["intersection"];
         $first->relations = $result["first"];
         $second->relations = $result["second"];
 
-        $result = $this->diffArray($this->getResourceRelations(), $other->getResourceRelations(), $strict);
+        $result = $this->diffArray($this->getResourceRelations(), $other->getResourceRelations(), $strict, $checkSubcomponents);
         $intersection->resourceRelations = $result["intersection"];
         $first->resourceRelations = $result["first"];
         $second->resourceRelations = $result["second"];
 
-        $result = $this->diffArray($this->getFunctions(), $other->getFunctions(), $strict);
+        $result = $this->diffArray($this->getFunctions(), $other->getFunctions(), $strict, $checkSubcomponents);
         $intersection->functions = $result["intersection"];
         $first->functions = $result["first"];
         $second->functions = $result["second"];
 
-        $result = $this->diffArray($this->getPlaces(), $other->getPlaces(), $strict);
+        $result = $this->diffArray($this->getPlaces(), $other->getPlaces(), $strict, $checkSubcomponents);
         $intersection->places = $result["intersection"];
         $first->places = $result["first"];
         $second->places = $result["second"];
 
-        $result = $this->diffArray($this->getSubjects(), $other->getSubjects(), $strict);
+        $result = $this->diffArray($this->getSubjects(), $other->getSubjects(), $strict, $checkSubcomponents);
         $intersection->subjects = $result["intersection"];
         $first->subjects = $result["first"];
         $second->subjects = $result["second"];
 
-        $result = $this->diffArray($this->getNationalities(), $other->getNationalities(), $strict);
+        $result = $this->diffArray($this->getNationalities(), $other->getNationalities(), $strict, $checkSubcomponents);
         $intersection->nationalities = $result["intersection"];
         $first->nationalities = $result["first"];
         $second->nationalities = $result["second"];
 
-        $result = $this->diffArray($this->getGenders(), $other->getGenders(), $strict);
+        $result = $this->diffArray($this->getGenders(), $other->getGenders(), $strict, $checkSubcomponents);
         $intersection->genders = $result["intersection"];
         $first->genders = $result["first"];
         $second->genders = $result["second"];
 
-        $result = $this->diffArray($this->getGeneralContexts(), $other->getGeneralContexts(), $strict);
+        $result = $this->diffArray($this->getGeneralContexts(), $other->getGeneralContexts(), $strict, $checkSubcomponents);
         $intersection->generalContexts = $result["intersection"];
         $first->generalContexts = $result["first"];
         $second->generalContexts = $result["second"];
 
-        $result = $this->diffArray($this->getStructureOrGenealogies(), $other->getStructureOrGenealogies(), $strict);
+        $result = $this->diffArray($this->getStructureOrGenealogies(), $other->getStructureOrGenealogies(), $strict, $checkSubcomponents);
         $intersection->structureOrGenealogies = $result["intersection"];
         $first->structureOrGenealogies = $result["first"];
         $second->structureOrGenealogies = $result["second"];
 
-        $result = $this->diffArray($this->getMandates(), $other->getMandates(), $strict);
+        $result = $this->diffArray($this->getMandates(), $other->getMandates(), $strict, $checkSubcomponents);
         $intersection->mandates = $result["intersection"];
         $first->mandates = $result["first"];
         $second->mandates = $result["second"];
 
-        $result = $this->diffArray($this->getDateList(), $other->getDateList(), $strict);
+        $result = $this->diffArray($this->getDateList(), $other->getDateList(), $strict, $checkSubcomponents);
         $intersection->dateList = $result["intersection"];
         $first->dateList = $result["first"];
         $second->dateList = $result["second"];
 
-        $result = $this->diffArray($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict);
+        $result = $this->diffArray($this->getSNACControlMetadata(), $other->getSNACControlMetadata(), $strict, $checkSubcomponents);
         $intersection->snacControlMetadata = $result["intersection"];
         $first->snacControlMetadata = $result["first"];
         $second->snacControlMetadata = $result["second"];
-        
+
         if (!$intersection->isEmpty())
             $return["intersection"] = $intersection;
 

--- a/src/snac/data/ConstellationRelation.php
+++ b/src/snac/data/ConstellationRelation.php
@@ -508,16 +508,17 @@ class ConstellationRelation extends AbstractData {
      *
      * @param \snac\data\ConstellationRelation $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\ConstellationRelation))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getSourceArkID() != $other->getSourceArkID() ||

--- a/src/snac/data/Contributor.php
+++ b/src/snac/data/Contributor.php
@@ -3,7 +3,7 @@
  * Contributor File
  *
  * Contains the data class for the contributors to names
- * 
+ *
  * License:
  *
  *
@@ -19,7 +19,7 @@ namespace snac\data;
  * Contributor Class
  *
  * Stores the contributor name (string) and type (a Term object)
- * 
+ *
  * @author Tom Laudeman
  * @author Robbie Hott
  *
@@ -28,7 +28,7 @@ class Contributor extends AbstractData {
 
     /**
      * @var \snac\data\Term Type of the contributor
-     * 
+     *
      *
      * From EAC-CPF tag(s):
      * vocabulary id for strings:
@@ -39,21 +39,21 @@ class Contributor extends AbstractData {
     private $type = null;
 
     /**
-     * @var \snac\data\Term Rule the contributor used to define this name entry 
+     * @var \snac\data\Term Rule the contributor used to define this name entry
      *
      */
     private $rule = null;
-    
+
     /**
      * @var string Name of the contributor.
-     * 
+     *
      * A simple string.
      */
     private $name = null;
-    
+
     /**
      * Constructor
-     * 
+     *
      * @param string[] $data optional An array of data to pre-fill this object
      */
     public function __construct($data = null) {
@@ -65,8 +65,8 @@ class Contributor extends AbstractData {
      * Get the type controlled vocab
      *
      * @return \snac\data\Term Type controlled vocabulary term
-     * 
-     */ 
+     *
+     */
     public function getType()
     {
         return $this->type;
@@ -76,8 +76,8 @@ class Contributor extends AbstractData {
      * Set the type controlled vocab
      *
      * @param \snac\data\Term $type Type controlled vocabulary term
-     * 
-     */ 
+     *
+     */
     public function setType($type)
     {
         $this->type = $type;
@@ -87,8 +87,8 @@ class Contributor extends AbstractData {
      * Get the rule controlled vocab
      *
      * @return \snac\data\Term Rule controlled vocabulary term
-     * 
-     */ 
+     *
+     */
     public function getRule()
     {
         return $this->rule;
@@ -98,8 +98,8 @@ class Contributor extends AbstractData {
      * Set the rule controlled vocab
      *
      * @param \snac\data\Term $rule Rule controlled vocabulary term
-     * 
-     */ 
+     *
+     */
     public function setRule($rule)
     {
         $this->rule = $rule;
@@ -141,7 +141,7 @@ class Contributor extends AbstractData {
             "rule" => $this->rule == null ? null : $this->rule->toArray($shorten),
             "name" => $this->name
         );
-            
+
         $return = array_merge($return, parent::toArray($shorten));
 
         // Shorten if necessary
@@ -193,25 +193,26 @@ class Contributor extends AbstractData {
      *
      * @param \snac\data\Contributor $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
-     *       
+     *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || !($other instanceof \snac\data\Contributor))
             return false;
-        
-        if (!parent::equals($other, $strict))
+
+        if (!parent::equals($other, $strict, $checkSubcomponents))
             return false;
-        
+
         if ($this->getName() != $other->getName())
             return false;
-        
+
         if (($this->getType() != null && !($this->getType()->equals($other->getType()))) ||
                 ($this->getType() == null && $other->getType() != null))
             return false;
-        
+
         return true;
     }
 }

--- a/src/snac/data/EntityId.php
+++ b/src/snac/data/EntityId.php
@@ -184,16 +184,17 @@ class EntityId extends AbstractData {
      *
      * @param \snac\data\EntityId $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\EntityId))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getText() != $other->getText())

--- a/src/snac/data/Image.php
+++ b/src/snac/data/Image.php
@@ -282,16 +282,17 @@ class Image extends AbstractData {
      *
      * @param \snac\data\Image $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Image))
             return false;
 
-        if (!parent::equals($other, $strict))
+        if (!parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getURL() != $other->getURL())

--- a/src/snac/data/Language.php
+++ b/src/snac/data/Language.php
@@ -231,15 +231,16 @@ class Language extends AbstractData {
      *
      * @param \snac\data\Language $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
         if ($other == null || ! ($other instanceof \snac\data\Language))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getVocabularySource() != $other->getVocabularySource())

--- a/src/snac/data/MaintenanceEvent.php
+++ b/src/snac/data/MaintenanceEvent.php
@@ -21,87 +21,87 @@ namespace snac\data;
  * Data storage class for maintenance events on an identity constellation.
  *
  * @author Robbie Hott
- *        
+ *
  */
 class MaintenanceEvent extends AbstractData {
 
     /**
-     * Event type 
-     * 
+     * Event type
+     *
      * From EAC-CPF tag(s):
-     * 
-     * * maintenanceEvent/eventType 
-     * 
+     *
+     * * maintenanceEvent/eventType
+     *
      * @var \snac\data\Term Event type
      */
     private $eventType;
 
     /**
      * Human-Readable Time
-     * 
+     *
      * From EAC-CPF tag(s):
-     * 
+     *
      * * maintenanceEvent/eventDateTime
-     * 
+     *
      * @var string Date and Time string of the event
      */
     private $eventDateTime;
 
     /**
      * Standard Date time
-     * 
+     *
      * From EAC-CPF tag(s):
-     * 
+     *
      * * maintenanceEvent/eventDateTime/@standardDateTime
-     * 
+     *
      * @var string Standardized date time of the event
-     * 
+     *
      */
     private $standardDateTime;
-    
+
     /**
      * Agent Type
-     * 
+     *
      * From EAC-CPF tag(s):
-     * 
+     *
      * * maintenanceEvent/agentType
-     * 
+     *
      * @var \snac\data\Term Type of the agent performing the event
      */
     private $agentType;
 
     /**
      * Agent
-     * 
+     *
      * From EAC-CPF tag(s):
-     * 
+     *
      * * maintenanceEvent/agent
-     * 
+     *
      * @var string Agent that performed the event
      */
     private $agent;
 
     /**
      * Description
-     * 
+     *
      * From EAC-CPF tag(s):
-     * 
+     *
      * * maintenanceEvent/eventDescription
-     * 
+     *
      * @var string Description of the event
      */
     private $eventDescription;
-    
+
     /**
      * Constructor
-     * 
+     *
      * @param string[] $data optional An array of data to pre-fill this object
      */
     public function __construct($data = null) {
         $this->setMaxDateCount(0);
         parent::__construct($data);
     }
-    
+
     /**
      * Returns this object's data as an associative array
      *
@@ -118,7 +118,7 @@ class MaintenanceEvent extends AbstractData {
             "agent" => $this->agent,
             "eventDescription" => $this->eventDescription
         );
-            
+
         $return = array_merge($return, parent::toArray($shorten));
 
         // Shorten if necessary
@@ -181,7 +181,7 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the event type.
-     * 
+     *
      * @param \snac\data\Term $eventType Event type
      */
     public function setEventType($eventType) {
@@ -191,7 +191,7 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the date and time of the event.
-     * 
+     *
      * @param string $eventDateTime DateTime string of the event
      */
     public function setEventDateTime($eventDateTime) {
@@ -201,7 +201,7 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the standardized date and time of the event.
-     * 
+     *
      * @param string $eventDateTime DateTime string of the event
      */
     public function setStandardDateTime($eventDateTime) {
@@ -211,7 +211,7 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the agent type.
-     * 
+     *
      * @param \snac\data\Term $agentType Agent type
      */
     public function setAgentType($agentType) {
@@ -221,7 +221,7 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the agent that performed the event.
-     * 
+     *
      * @param string $agent Agent
      */
     public function setAgent($agent) {
@@ -231,62 +231,62 @@ class MaintenanceEvent extends AbstractData {
 
     /**
      * Set the event description.
-     * 
+     *
      * @param string $eventDescription Description of the event
      */
     public function setEventDescription($eventDescription) {
 
         $this->eventDescription = $eventDescription;
     }
-    
+
     /**
      * Get the event type
-     * 
+     *
      * @return \snac\data\Term event type
      */
     public function getEventType() {
         return $this->eventType;
     }
-    
+
     /**
      * Get the event date time
-     * 
+     *
      * @return string date and time string
      */
     public function getEventDateTime() {
         return $this->eventDateTime;
     }
-    
+
     /**
      * Get the event description
-     * 
+     *
      * @return string description
      */
     public function getEventDescription() {
         return $this->eventDescription;
     }
-    
+
     /**
      * Get the agent type
-     * 
+     *
      * @return \snac\data\Term agent type
      */
     public function getAgentType() {
         return $this->agentType;
     }
-    
+
     /**
      * Get the agent
-     * 
+     *
      * @return string agent name
      */
     public function getAgent() {
         return $this->agent;
     }
-    
+
     /**
      * Get the standard date and time
-     * 
+     *
      * @return string standardized date and time
      */
     public function getStandardDateTime() {
@@ -299,18 +299,19 @@ class MaintenanceEvent extends AbstractData {
      *
      * @param \snac\data\Language $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
-     *       
+     *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\MaintenanceEvent))
             return false;
-        
-        if (! parent::equals($other, $strict))
+
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
-        
+
         if ($this->getEventDateTime() != $other->getEventDateTime())
             return false;
         if ($this->getStandardDateTime() != $other->getStandardDateTime())
@@ -319,14 +320,14 @@ class MaintenanceEvent extends AbstractData {
             return false;
         if ($this->getEventDescription() != $other->getEventDescription())
             return false;
-        
+
         if (($this->getEventType() != null && ! $this->getEventType()->equals($other->getEventType())) ||
                  ($this->getEventType() == null && $other->getEventType() != null))
             return false;
         if (($this->getAgentType() != null && ! $this->getAgentType()->equals($other->getAgentType())) ||
                  ($this->getAgentType() == null && $other->getAgentType() != null))
             return false;
-        
+
         return true;
     }
 }

--- a/src/snac/data/NameEntry.php
+++ b/src/snac/data/NameEntry.php
@@ -311,16 +311,17 @@ class NameEntry extends AbstractData {
      *
      * @param \snac\data\NameEntry $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
-
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
+        
         if ($other == null || ! ($other instanceof \snac\data\NameEntry))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getOriginal() != $other->getOriginal())
@@ -328,15 +329,17 @@ class NameEntry extends AbstractData {
         if ($this->getPreferenceScore() != $other->getPreferenceScore())
             return false;
 
-        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict)) ||
+        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict, $checkSubcomponents)) ||
                  ($this->getLanguage() == null && $other->getLanguage() != null))
             return false;
 
-        if (!$this->checkArrayEqual($this->getComponents(), $other->getComponents(), $strict))
-            return false;
+        if ($checkSubcomponents) {
+            if (!$this->checkArrayEqual($this->getComponents(), $other->getComponents(), $strict, $checkSubcomponents))
+                return false;
 
-        if (!$this->checkArrayEqual($this->getContributors(), $other->getContributors(), $strict))
-            return false;
+            if (!$this->checkArrayEqual($this->getContributors(), $other->getContributors(), $strict, $checkSubcomponents))
+                return false;
+        }
 
         return true;
     }

--- a/src/snac/data/Occupation.php
+++ b/src/snac/data/Occupation.php
@@ -231,16 +231,17 @@ class Occupation extends AbstractData {
      *
      * @param \snac\data\Occupation $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Occupation))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getVocabularySource() != $other->getVocabularySource())

--- a/src/snac/data/OriginationName.php
+++ b/src/snac/data/OriginationName.php
@@ -120,16 +120,17 @@ class OriginationName extends AbstractData {
      *
      * @param \snac\data\RROriginationName $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || !($other instanceof \snac\data\OriginationName))
             return false;
 
-        if (!parent::equals($other, $strict))
+        if (!parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getName() != $other->getName())

--- a/src/snac/data/Place.php
+++ b/src/snac/data/Place.php
@@ -476,16 +476,17 @@ class Place extends AbstractData {
      *
      * @param \snac\data\Place $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Place))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getOriginal() != $other->getOriginal())
@@ -507,7 +508,7 @@ class Place extends AbstractData {
                  ($this->getGeoTerm() == null && $other->getGeoTerm() != null))
             return false;
 
-        if (!$this->checkArrayEqual($this->getAddress(), $other->getAddress(), $strict))
+        if (!$this->checkArrayEqual($this->getAddress(), $other->getAddress(), $strict, $checkSubcomponents))
             return false;
 
         return true;

--- a/src/snac/data/Resource.php
+++ b/src/snac/data/Resource.php
@@ -548,16 +548,17 @@ class Resource extends AbstractData {
      *
      * @param \snac\data\ResourceRelation $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Resource))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getTitle() != $other->getTitle())
@@ -570,10 +571,10 @@ class Resource extends AbstractData {
         // Equals cannot check the Origination Names and Languages, since some times
         // for performance reasons we do not grab them.
         /**
-        if (!$this->checkArrayEqual($this->getOriginationNames(), $other->getOriginationNames(), $strict)) {
+        if (!$this->checkArrayEqual($this->getOriginationNames(), $other->getOriginationNames(), $strict, $checkSubcomponents)) {
             return false;
         }
-        if (!$this->checkArrayEqual($this->getLanguages(), $other->getLanguages(), $strict))
+        if (!$this->checkArrayEqual($this->getLanguages(), $other->getLanguages(), $strict, $checkSubcomponents))
             return false;
         **/
 

--- a/src/snac/data/ResourceRelation.php
+++ b/src/snac/data/ResourceRelation.php
@@ -254,16 +254,17 @@ class ResourceRelation extends AbstractData {
      *
      * @param \snac\data\ResourceRelation $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\ResourceRelation))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getContent() != $other->getContent())

--- a/src/snac/data/SNACControlMetadata.php
+++ b/src/snac/data/SNACControlMetadata.php
@@ -300,16 +300,17 @@ class SNACControlMetadata extends AbstractData {
      *
      * @param \snac\data\SNACControlMetadata $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\SNACControlMetadata))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getSubCitation() != $other->getSubCitation())
@@ -330,7 +331,7 @@ class SNACControlMetadata extends AbstractData {
                  ($this->getDescriptiveRule() == null && $other->getDescriptiveRule() != null))
             return false;
 
-        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict)) ||
+        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict, $checkSubcomponents)) ||
                  ($this->getLanguage() == null && $other->getLanguage() != null))
             return false;
 

--- a/src/snac/data/SNACDate.php
+++ b/src/snac/data/SNACDate.php
@@ -654,16 +654,17 @@ class SNACDate extends AbstractData {
      *
      * @param \snac\data\SNACDate $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\SNACDate))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getFromBC() != $other->getFromBC())

--- a/src/snac/data/SNACFunction.php
+++ b/src/snac/data/SNACFunction.php
@@ -266,16 +266,17 @@ class SNACFunction extends AbstractData {
      *
      * @param \snac\data\SNACFunction $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\SNACFunction))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getVocabularySource() != $other->getVocabularySource())

--- a/src/snac/data/SameAs.php
+++ b/src/snac/data/SameAs.php
@@ -184,16 +184,17 @@ class SameAs extends AbstractData {
      *
      * @param \snac\data\SameAs $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\SameAs))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($this->getText() != $other->getText())

--- a/src/snac/data/Source.php
+++ b/src/snac/data/Source.php
@@ -276,16 +276,17 @@ class Source extends AbstractData {
      *
      * @param \snac\data\Source $other Other object
      * @param boolean $strict optional Whether or not to check id, version, and operation
+     * @param boolean $checkSubcomponents optional Whether or not to check SNACControlMetadata, nameEntries contributors & components
      * @return boolean true on equality, false otherwise
      *
      * @see \snac\data\AbstractData::equals()
      */
-    public function equals($other, $strict = true) {
+    public function equals($other, $strict = true, $checkSubcomponents = true) {
 
         if ($other == null || ! ($other instanceof \snac\data\Source))
             return false;
 
-        if (! parent::equals($other, $strict))
+        if (! parent::equals($other, $strict, $checkSubcomponents))
             return false;
 
         if ($strict && ($this->getDisplayName() != $other->getDisplayName()))
@@ -302,7 +303,7 @@ class Source extends AbstractData {
         //         ($this->getType() == null && $other->getType() != null))
         //    return false;
 
-        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict)) ||
+        if (($this->getLanguage() != null && ! $this->getLanguage()->equals($other->getLanguage(), $strict, $checkSubcomponents)) ||
                  ($this->getLanguage() == null && $other->getLanguage() != null))
             return false;
 

--- a/src/snac/server/reporting/ReportingEngine.php
+++ b/src/snac/server/reporting/ReportingEngine.php
@@ -48,7 +48,7 @@ class ReportingEngine {
     public function __construct() {
         global $log;
         // create a log channel
-        $this->logger = new \Monolog\Logger('Server');
+        $this->logger = new \Monolog\Logger('ReportingEngine');
         $this->logger->pushHandler($log);
         
         $this->reports = array();

--- a/test/snac/data/ConstellationTest.php
+++ b/test/snac/data/ConstellationTest.php
@@ -19,7 +19,7 @@ namespace test\snac\data;
  *
  */
 class ConstellationTest extends \PHPUnit\Framework\TestCase {
-    
+
     /**
      * Test that trying to read garbage instead of JSON results in not importing any data
      */
@@ -331,7 +331,7 @@ class ConstellationTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * Test that equals() can ignore subcomponents
+     * Test that equals() can ignore metadata
      */
      public function testEqualsCanIgnoreMetadata() {
          $id1 = new \snac\data\Constellation();
@@ -352,6 +352,9 @@ class ConstellationTest extends \PHPUnit\Framework\TestCase {
          $this->assertTrue($id1->equals($id2, false, false), "Equals failed to ignore SNACControlMetadata");
      }
 
+     /**
+      * Test that equals() can ignore NameEntry contributors
+      */
      public function testEqualsCanIgnoreContributors() {
          $id1 = new \snac\data\Constellation();
          $id2 = new \snac\data\Constellation();
@@ -372,13 +375,20 @@ class ConstellationTest extends \PHPUnit\Framework\TestCase {
         $id1->addNameEntry($name1);
         $id2->addNameEntry($name2);
 
-        //should be inequal with $stict and $checkSubcomponents
+        //should be inequal with $strict and $checkSubcomponents
         $this->assertFalse($id1->equals($id2, true, true));
+        //should be inequal with $checkSubcomponents
+        $this->assertFalse($id1->equals($id2, false, true));
 
-        //should be equal without $stict and $checkSubcomponents
+        $this->assertTrue($id1->equals($id2, true, false));
+
+        //should be equal without $strict and $checkSubcomponents
         $this->assertTrue($id1->equals($id2, false, false), "Equals failed to ignore contributors");
      }
 
+     /**
+      * Test that equals() can ignore NameEntry components
+      */
      public function testEqualsCanIgnoreComponents() {
          $id1 = new \snac\data\Constellation();
          $id2 = new \snac\data\Constellation();
@@ -399,10 +409,15 @@ class ConstellationTest extends \PHPUnit\Framework\TestCase {
         $id1->addNameEntry($name1);
         $id2->addNameEntry($name2);
 
-        //should be inequal with $stict and $checkSubcomponents
+        //should be inequal with $strict and $checkSubcomponents
         $this->assertFalse($id1->equals($id2, true, true));
+        //should be inequal with $checkSubcomponents
+        $this->assertFalse($id1->equals($id2, false, true));
 
-        //should be equal without $stict and $checkSubcomponents
+        $this->assertTrue($id1->equals($id2, true, false));
+
+
+        //should be equal without $strict and $checkSubcomponents
         $this->assertTrue($id1->equals($id2, false, false), "Equals failed to ignore components");
      }
 


### PR DESCRIPTION
Allow equals() to ignore subcomponents (SNACControlMetadata, NameEntries' contributors & components).