### PR TITLE
Added quick fix to server executor when Constellation doesn't have a …

### DIFF
--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -3185,12 +3185,18 @@ class ServerExecutor {
         $response["results"] = array ();
         if ($list !== false) {
             foreach ($list as $constellation) {
+                // Error handling
+                if ($constellation->getPreferredNameEntry() == null) {
+                    $this->logger->addError("Constellation did not have name entry", $constellation->toArray());
+                    continue;
+                }
+
                 $item = array (
                     "id" => $constellation->getID(),
                     "version" => $constellation->getVersion(),
                     "nameEntry" => $constellation->getPreferredNameEntry()->getOriginal()
                 );
-                $this->logger->addDebug("Needs Review", $item);
+                $this->logger->addDebug("Listing (".$status.")", $item);
                 array_push($response["results"], $item);
             }
         }


### PR DESCRIPTION
My copy of SNAC had a Constellation without a name, and so this caused SNAC to crash.  By adding this, it should now just write an error to the log file and continue processing as if that Constellation didn't exist.