### PR TITLE
Correct all instances of 'tombstoned' statuses to 'tombstone'

### DIFF
--- a/src/snac/server/database/DBUtil.php
+++ b/src/snac/server/database/DBUtil.php
@@ -907,7 +907,7 @@ class DBUtil
         $history = $this->listVersionHistory($mainID, $version, false);
 
         foreach ($history as $event) {
-            if ($event['status'] == 'published' || $event['status'] == 'deleted' || $event['status'] == 'tombstoned')
+            if ($event['status'] == 'published' || $event['status'] == 'deleted' || $event['status'] == 'tombstone')
                 return null;
             else if ($event["status"] == 'needs review' || $event["status"] == 'change locks')
                 return $event;

--- a/src/snac/server/reporting/reports/NumConstellations.php
+++ b/src/snac/server/reporting/reports/NumConstellations.php
@@ -45,9 +45,9 @@ class NumConstellations extends helpers\Report {
         $sql = "select count(*)
                 from version_history as aa,
                     (select max(version) as version, id from version_history
-                    where status in ('published', 'tombstoned', 'deleted', 'embargoed')
+                    where status in ('published', 'tombstone', 'deleted', 'embargoed')
                     group by id) as cc
-                where              
+                where
                     aa.id=cc.id and
                     aa.version=cc.version and
                     aa.status = 'published';";

--- a/src/snac/server/reporting/reports/NumConstellationsByType.php
+++ b/src/snac/server/reporting/reports/NumConstellationsByType.php
@@ -42,18 +42,18 @@ class NumConstellationsByType extends helpers\Report {
      * @return string[]       Report results
      */
     public function compute($psql) {
-        $sql = "select v.value, count(*) from 
+        $sql = "select v.value, count(*) from
             (select distinct v.value, cc.id
                 from version_history as aa,
-                    (select n.ic_id, n.entity_type, b.version from nrd n, 
+                    (select n.ic_id, n.entity_type, b.version from nrd n,
                         (select max(version) as version, ic_id from nrd
                         group by ic_id) as b where n.ic_id = b.ic_id and
-                        not n.is_deleted) as bb, 
+                        not n.is_deleted) as bb,
                     (select max(version) as version, id from version_history
-                    where status in ('published', 'tombstoned', 'deleted', 'embargoed')
+                    where status in ('published', 'tombstone', 'deleted', 'embargoed')
                     group by id) as cc,
                     vocabulary v
-                where              
+                where
                     aa.id=cc.id and
                     aa.version=cc.version and
                     bb.ic_id=cc.id and

--- a/src/snac/server/reporting/reports/NumNewConstellationsThisWeek.php
+++ b/src/snac/server/reporting/reports/NumNewConstellationsThisWeek.php
@@ -45,9 +45,9 @@ class NumNewConstellationsThisWeek extends helpers\Report {
         $sql = "select count(*)
                 from version_history as aa,
                     (select min(timestamp) as timestamp, id from version_history
-                    where status in ('published', 'tombstoned', 'deleted', 'embargoed')
+                    where status in ('published', 'tombstone', 'deleted', 'embargoed')
                     group by id) as cc
-                where              
+                where
                     aa.id=cc.id and
                     aa.version=cc.version and
                     cc.timestamp > NOW() - INTERVAL '7 days' and
@@ -66,4 +66,3 @@ class NumNewConstellationsThisWeek extends helpers\Report {
     }
 
 }
-

--- a/src/snac/server/reporting/reports/PublishesLastMonth.php
+++ b/src/snac/server/reporting/reports/PublishesLastMonth.php
@@ -45,7 +45,7 @@ class PublishesLastMonth extends helpers\Report {
         $sql = "select count(*), date_trunc('day', timestamp) as date
                     from version_history
                     where
-                        status in ('published', 'tombstoned', 'deleted', 'embargoed') and
+                        status in ('published', 'tombstone', 'deleted', 'embargoed') and
                         timestamp > NOW() - INTERVAL '31 days'
                     group by date
                     order by date asc;";

--- a/src/snac/server/reporting/reports/TopEditorsThisWeek.php
+++ b/src/snac/server/reporting/reports/TopEditorsThisWeek.php
@@ -46,10 +46,10 @@ class TopEditorsThisWeek extends helpers\Report {
                     (select count(*), user_id
                         from version_history
                         where
-                            status in ('needs review', 'published', 'tombstoned', 'deleted', 'embargoed') and
+                            status in ('needs review', 'published', 'tombstone', 'deleted', 'embargoed') and
                             timestamp > NOW() - INTERVAL '7 days' and
                             user_id > 100
-                        group by user_id) b, 
+                        group by user_id) b,
                     appuser a
                 where b.user_id = a.id
                 order by b.count desc
@@ -69,4 +69,3 @@ class TopEditorsThisWeek extends helpers\Report {
     }
 
 }
-


### PR DESCRIPTION
This PR makes all tombstone statuses consistent in codebase. 

I would actually prefer if we went with 'tombstoned', as that would be consistent with 'published', and 'deleted', but that would require updating any 'tombstone' statuses in the database. 