### PR TITLE
Load wikimedia images via https.

### DIFF
--- a/src/snac/client/webui/templates/grid_page.html
+++ b/src/snac/client/webui/templates/grid_page.html
@@ -231,7 +231,7 @@ $(document).ready(function() {
                     <div class="thumbnail" id="thumbnail_img_{{loop.index}}">
                         <div style="float: none;" class="wikipedia_thumbnail">
                             <a href="{{control.snacURL}}/view/{{constellation.id}}">
-                                <img src="{{constellation.images.0.url}}?width=300"
+                                <img src="{{constellation.images.0.url|replace({'http://' : 'https://'})}}?width=300"
                                      alt="[thumbnail]" id="img_{{loop.index}}"></img>
                             </a>
                             <div>

--- a/src/virtualhosts/www/javascript/wikipedia_image.js
+++ b/src/virtualhosts/www/javascript/wikipedia_image.js
@@ -44,7 +44,7 @@ $(document).ready(function() {
         $.get("https://query.wikidata.org/sparql?format=json&query="+query, null, function (data) {
             if (data.results && data.results.bindings
                     && data.results.bindings[0] && data.results.bindings[0]["_image"]) {
-                var imageURL = data.results.bindings[0]["_image"].value;
+                var imageURL = data.results.bindings[0]["_image"].value.replace("http://", "https://");
 
                 var parts = imageURL.split("/Special:FilePath/");
                 var file = parts[1];


### PR DESCRIPTION
These are temporary fixes to force the https load. We will want to update the cached image urls on the ES indexes, as well as get https urls from the SPARQL query if possible.