### PR TITLE
return id as a string per Reconciliation Service API

### DIFF
--- a/src/snac/client/openrefine/OpenRefine.php
+++ b/src/snac/client/openrefine/OpenRefine.php
@@ -106,7 +106,7 @@ class OpenRefine implements \snac\interfaces\ServerInterface {
                     // build the CSV line to print
                     $output = array(
                         "name" => $result["identity"]["nameEntries"][0]["original"],
-                        "id" => $result["identity"]["id"],
+                        "id" => (string) $result["identity"]["id"],
                         "type" => [ 
                             $result["identity"]["entityType"]["term"] 
                         ],
@@ -155,7 +155,7 @@ class OpenRefine implements \snac\interfaces\ServerInterface {
                         // build the results line
                         $output = array(
                             "name" => $result["identity"]["nameEntries"][0]["original"],
-                            "id" => $result["identity"]["id"],
+                            "id" => (string) $result["identity"]["id"],
                             "type" => [$result["identity"]["entityType"]["term"]],
                             "score" => round($result["strength"], 2),
                             "match" => ($result["strength"] > 11 ? true : false)


### PR DESCRIPTION
OpenRefine versions up to 2.8 were more permissive in their parsing of Reconciliation API results, treating the SNAC numeric id values as strings.  Starting with OpenRefine 3, reconciliation stopped producing the expected results, but did not indicate any error to the user.  Casting the id values to strings [as specified](https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-API#query-response) fixes this issue.