### PR TITLE
Api keys

### DIFF
--- a/install/sql_files/api_keys.sql
+++ b/install/sql_files/api_keys.sql
@@ -1,6 +1,6 @@
 -- API keys table
 create table api_keys (
-        id          int  primary key default nextval('id_seq'),
+        id          serial primary key,
         uid         int not null,       -- fk to appuser.id
         label       text,               -- user provided name of this api key 
         key         text not null,      -- the key

--- a/install/sql_files/api_keys.sql
+++ b/install/sql_files/api_keys.sql
@@ -1,0 +1,12 @@
+-- API keys table
+create table api_keys (
+        id          int  primary key default nextval('id_seq'),
+        uid         int not null,       -- fk to appuser.id
+        label       text,               -- user provided name of this api key 
+        key         text not null,      -- the key
+        generated   timestamp default(now()), -- time created
+        expires     timestamp default(now() + interval '1 year') -- expiration time
+        );
+
+        create index api_keys_idx2 on api_keys(key);
+        create index api_keys_idx3 on api_keys(uid);

--- a/src/snac/client/rest/commands.json
+++ b/src/snac/client/rest/commands.json
@@ -425,7 +425,10 @@
         "title" : "Insert New Constellation",
         "description" : "Insert a new Constellation into SNAC. The Constellation must have the operation flags set to \"insert\".",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object"
@@ -535,7 +538,10 @@
         "title" : "Update Constellation",
         "description" : "Updates SNAC's copy of the given Constellation with this one.  Any components with operation flags set to \"update\" will be overwritten with the new version.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object, with current ids and versions (the result of calling edit)"
@@ -624,7 +630,10 @@
         "title" : "Publish Constellation",
         "description" : "Publishes the given Constellation in SNAC.  This does not make any updates to the Constellation data in SNAC.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object, with current ids and versions (the result of calling edit)"
@@ -683,7 +692,10 @@
         "title" : "Unlock Constellation",
         "description" : "Drops the lock on the given Constellation from \"currently editing\" down to simply locked to the user.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object with current ID and Version number"
@@ -736,7 +748,10 @@
         "title" : "Send Constellation for Review",
         "description" : "Sends the given Constellation in SNAC for review.  This does not make any updates to the Constellation data in SNAC.  If a reviewer is specified, this query will put the Constellation in that user's review queue.  If no reviewer is specified, the Constellation will go for general review.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "reviewer" : {
                 "type": "Object",
                 "description": "User object of the intended reviewer",
@@ -801,7 +816,10 @@
         "title" : "Delete Constellation",
         "description" : "Deletes the given Constellation from SNAC.  This does not make any updates to the Constellation data in SNAC before deleting.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object to delete with at least current ID and Version"
@@ -854,7 +872,10 @@
         "title" : "Reassign Constellation to Another User",
         "description" : "Reassigns the given Constellation to a different user, i.e. changes which user to which the Constellation is locked.  This does not make any updates to the Constellation data in SNAC.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object to assign, with at least current ID and Version"
@@ -1030,7 +1051,10 @@
         "title" : "List Constellations",
         "description" : "Returns a list of Constellations based on the query parameters.  By default, it will return a subset of published Constellations.  If a user object is supplied, additional statuses are allowed to be queried, including \"needs review\" for all Constellations needing review.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "status" : {
                 "type": "String",
                 "description": "Status of Constellations to return.  Currently supported: \"published\" (default) and \"needs review\"",
@@ -1251,7 +1275,11 @@
         "title" : "List Maybe-Same Constellations",
         "description" : "Returns a list of Constellations denoted as maybe-same-as the given Constellation.  If the user object is given, it will contain mergeable flags to denote if the user has permission to merge any of the Constellations.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key",
+                "optional": true
+            },
             "constellationid" : {
                 "type" : "Integer",
                 "description" : "Constellation ID"
@@ -1375,7 +1403,10 @@
         "title" : "Add Maybe-Same Constellation Assertions",
         "description" : "Makes a maybe-same assertion between the constellations specified.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "assertion" : {
                 "type": "String",
                 "description" : "User's assertion statement about the similarity of these Constellations"
@@ -1470,7 +1501,10 @@
         "title" : "Compute Constellation Diff and Set Merge",
         "description" : "Computes the difference between the two given Constellations.  Checks out the two Constellations in editing for the given user to allow a merge.  Returns Constellation objects containing: only those items in the first, only those items in the second, and components shared.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellationid1" : {
                 "type": "Integer",
                 "description" :  "Constellation ID for one Constellation to compare"
@@ -1523,7 +1557,10 @@
         "title" : "Merge Constellations",
         "description" : "Given Constellation IDs and a full, merged, Constellation, creates a new Constellation in SNAC from the given Constellation and sets all Constellations given by the IDs to be \"tombstoned\" and redirected to the new, merged, Constellation.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellationids" : {
                 "type": "Array of Integers",
                 "description" :  "2 or more Constellation IDs to merge together.  Each Constellation will be \"tombstoned\" and point to a new Constellation that matches the one provided by the user in the Constellation parameter."
@@ -1601,7 +1638,10 @@
         "title" : "Automatically Merge Constellations",
         "description" : "Given Constellation IDs, creates a new Constellation in SNAC from the combined data from all Constellations, \"tombstones\" the originals, and redirects thier IDs to the new, merged, Constellation.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellationids" : {
                 "type": "Array of Integers",
                 "description" :  "2 or more Constellation IDs to merge together.  Each Constellation will be \"tombstoned\" and point to a new Constellation that matches the one provided by the user in the Constellation parameter."
@@ -1769,7 +1809,10 @@
         "title" : "Edit Constellation",
         "description" : "Check out the Constellation for editing.",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellationid" : {
                 "type" : "Integer",
                 "description" : "Constellation ID for Constellation to edit"
@@ -2376,7 +2419,10 @@
                 "type": "Object",
                 "description": "Resource object to write to SNAC, with \"operation\" set to \"insert\"."
             },
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            }
         },
         "returns" : {
             "resource": {
@@ -2417,7 +2463,7 @@
                         },
                         "operation": "insert"
                     },
-                    "apikey" : "...",
+                    "apikey" : "..."
                 },
                 "response":{
                     "resource": {
@@ -3191,7 +3237,10 @@
         "description": "Links a constellation to an external identity on sites such as Wikipedia, VIAF, etc.",
         "category": "modification",
         "parameters" : {
-            "apikey" : "...",
+            "apikey" : {
+                "type" : "String",
+                "description" : "Valid API Key"
+            },
             "constellationid" : {
                 "type": "Integer",
                 "description": "Constellation ID"
@@ -3209,7 +3258,7 @@
                    "command" : "add_sameas",
                    "constellationid" : 73093297,
                    "sameas_uris": ["https://en.wikipedia.org/wiki/Franciscus_Gomarus", "https://id.loc.gov/authorities/names/nb98048106"],
-                   "apikey" : "...",
+                   "apikey" : "..."
                 },
                 "response":{
                     "constellation": {

--- a/src/snac/client/rest/commands.json
+++ b/src/snac/client/rest/commands.json
@@ -425,10 +425,7 @@
         "title" : "Insert New Constellation",
         "description" : "Insert a new Constellation into SNAC. The Constellation must have the operation flags set to \"insert\".",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object"
@@ -459,7 +456,7 @@
                 "description": "Inserting a Constellation with only one nameEntry",
                 "query": {
                     "command": "insert_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "constellation": {
                         "dataType": "Constellation",
                         "operation": "insert",
@@ -538,10 +535,7 @@
         "title" : "Update Constellation",
         "description" : "Updates SNAC's copy of the given Constellation with this one.  Any components with operation flags set to \"update\" will be overwritten with the new version.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object, with current ids and versions (the result of calling edit)"
@@ -572,7 +566,7 @@
                 "description": "Update a Constellation with only one nameEntry",
                 "query": {
                     "command": "update_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "constellation": {
                         "dataType": "Constellation",
                         "id": "76813079",
@@ -630,10 +624,7 @@
         "title" : "Publish Constellation",
         "description" : "Publishes the given Constellation in SNAC.  This does not make any updates to the Constellation data in SNAC.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Full Constellation object, with current ids and versions (the result of calling edit)"
@@ -664,7 +655,7 @@
                 "description": "When publishing, only the bare Constellation object is required to perform the publish.",
                 "query": {
                     "command": "publish_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "constellation": {
                         "dataType": "Constellation",
                         "id": "76813079",
@@ -692,10 +683,7 @@
         "title" : "Unlock Constellation",
         "description" : "Drops the lock on the given Constellation from \"currently editing\" down to simply locked to the user.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object with current ID and Version number"
@@ -721,7 +709,7 @@
                 "description": "When unlocking, only the bare Constellation object is required to perform the unlock.",
                 "query": {
                     "command": "unlock_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "constellation": {
                         "dataType": "Constellation",
                         "id": "76813079",
@@ -748,10 +736,7 @@
         "title" : "Send Constellation for Review",
         "description" : "Sends the given Constellation in SNAC for review.  This does not make any updates to the Constellation data in SNAC.  If a reviewer is specified, this query will put the Constellation in that user's review queue.  If no reviewer is specified, the Constellation will go for general review.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "reviewer" : {
                 "type": "Object",
                 "description": "User object of the intended reviewer",
@@ -787,7 +772,7 @@
                 "description": "When sending for review, only the bare Constellation object is required to perform the request.",
                 "query": {
                     "command": "review_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "reviewer": { "..." : "..." },
                     "constellation": {
                         "dataType": "Constellation",
@@ -816,10 +801,7 @@
         "title" : "Delete Constellation",
         "description" : "Deletes the given Constellation from SNAC.  This does not make any updates to the Constellation data in SNAC before deleting.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object to delete with at least current ID and Version"
@@ -845,7 +827,7 @@
                 "description": "When deleting, only the bare Constellation object is required to perform the request.",
                 "query": {
                     "command": "delete_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "constellation": {
                         "dataType": "Constellation",
                         "id": "76813079",
@@ -872,10 +854,7 @@
         "title" : "Reassign Constellation to Another User",
         "description" : "Reassigns the given Constellation to a different user, i.e. changes which user to which the Constellation is locked.  This does not make any updates to the Constellation data in SNAC.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "Acting user's User object"
-            },
+            "apikey" : "...",
             "constellation" : {
                 "type": "Object",
                 "description": "Constellation object to assign, with at least current ID and Version"
@@ -905,7 +884,7 @@
                 "description": "When reassigning a Constellation, only the bare Constellation object is required to perform the request.",
                 "query": {
                     "command": "reassign_constellation",
-                    "user": { "..." : "..." },
+                    "apikey" : "...",
                     "to_user": { "..." : "..." },
                     "constellation": {
                         "dataType": "Constellation",
@@ -1051,11 +1030,7 @@
         "title" : "List Constellations",
         "description" : "Returns a list of Constellations based on the query parameters.  By default, it will return a subset of published Constellations.  If a user object is supplied, additional statuses are allowed to be queried, including \"needs review\" for all Constellations needing review.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "Acting user's User object",
-                "optional": true
-            },
+            "apikey" : "...",
             "status" : {
                 "type": "String",
                 "description": "Status of Constellations to return.  Currently supported: \"published\" (default) and \"needs review\"",
@@ -1276,11 +1251,7 @@
         "title" : "List Maybe-Same Constellations",
         "description" : "Returns a list of Constellations denoted as maybe-same-as the given Constellation.  If the user object is given, it will contain mergeable flags to denote if the user has permission to merge any of the Constellations.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object",
-                "optional": true
-            },
+            "apikey" : "...",
             "constellationid" : {
                 "type" : "Integer",
                 "description" : "Constellation ID"
@@ -1310,7 +1281,7 @@
                 "description": "",
                 "query": {
                     "command" : "constellation_list_maybesame",
-                    "user" : { "...":"..." },
+                    "apikey" : "...",
                     "constellationid" : 66598997
                 },
                 "response" : {
@@ -1404,10 +1375,7 @@
         "title" : "Add Maybe-Same Constellation Assertions",
         "description" : "Makes a maybe-same assertion between the constellations specified.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description" : "User object"
-            },
+            "apikey" : "...",
             "assertion" : {
                 "type": "String",
                 "description" : "User's assertion statement about the similarity of these Constellations"
@@ -1433,7 +1401,7 @@
                 "description": "",
                 "query" : {
                    "command" : "constellation_add_maybesame",
-                   "user" : { "...":"..." },
+                   "apikey" : "...",
                    "constellationids" : [123456, 987654, 626505],
                    "assertion": "These three all have the same name and come from the same holding institution"
                 },
@@ -1480,7 +1448,7 @@
                 "description": "",
                 "query" : {
                    "command" : "constellation_diff",
-                   "user" : { "...":"..." },
+                   "apikey" : "...",
                    "constellationid1" : 123456,
                    "constellationid2" : 987654
                 },
@@ -1502,10 +1470,7 @@
         "title" : "Compute Constellation Diff and Set Merge",
         "description" : "Computes the difference between the two given Constellations.  Checks out the two Constellations in editing for the given user to allow a merge.  Returns Constellation objects containing: only those items in the first, only those items in the second, and components shared.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description" : "User object"
-            },
+            "apikey" : "...",
             "constellationid1" : {
                 "type": "Integer",
                 "description" :  "Constellation ID for one Constellation to compare"
@@ -1539,7 +1504,7 @@
                 "description": "If the given user has permission to check both Constellations out for editing, then the system will automatically check them out to the user, produce the diff, and denote to the user in the mergeable flag that the user may merge these constellations.",
                 "query" : {
                    "command" : "constellation_diff_merge",
-                   "user" : { "...":"..." },
+                   "apikey" : "...",
                    "constellationid1" : 123456,
                    "constellationid2" : 987654
                 },
@@ -1558,10 +1523,7 @@
         "title" : "Merge Constellations",
         "description" : "Given Constellation IDs and a full, merged, Constellation, creates a new Constellation in SNAC from the given Constellation and sets all Constellations given by the IDs to be \"tombstoned\" and redirected to the new, merged, Constellation.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description" : "User object"
-            },
+            "apikey" : "...",
             "constellationids" : {
                 "type": "Array of Integers",
                 "description" :  "2 or more Constellation IDs to merge together.  Each Constellation will be \"tombstoned\" and point to a new Constellation that matches the one provided by the user in the Constellation parameter."
@@ -1591,7 +1553,7 @@
                 "description": "If we want to merge three Constellations into one, which only has a name entry, we would provide all IDs and the appropriate merged version.",
                 "query" : {
                    "command" : "constellation_merge",
-                   "user" : { "...":"..." },
+                   "apikey" : "...",
                    "constellationids" : [123456, 987654, 626505],
                    "constellation": {
                        "dataType": "Constellation",
@@ -1639,10 +1601,7 @@
         "title" : "Automatically Merge Constellations",
         "description" : "Given Constellation IDs, creates a new Constellation in SNAC from the combined data from all Constellations, \"tombstones\" the originals, and redirects thier IDs to the new, merged, Constellation.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description" : "User object"
-            },
+            "apikey" : "...",
             "constellationids" : {
                 "type": "Array of Integers",
                 "description" :  "2 or more Constellation IDs to merge together.  Each Constellation will be \"tombstoned\" and point to a new Constellation that matches the one provided by the user in the Constellation parameter."
@@ -1668,7 +1627,7 @@
                 "description": "If we want to merge three Constellations into one, which only has a name entry, we would provide all IDs and the system automatically creates a merged version.",
                 "query" : {
                    "command" : "constellation_auto_merge",
-                   "user" : { "...":"..." },
+                   "apikey" : "...",
                    "constellationids" : [123456, 987654, 626505]
                 },
                 "response": {
@@ -1810,10 +1769,7 @@
         "title" : "Edit Constellation",
         "description" : "Check out the Constellation for editing.",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description" : "User object"
-            },
+            "apikey" : "...",
             "constellationid" : {
                 "type" : "Integer",
                 "description" : "Constellation ID for Constellation to edit"
@@ -1839,7 +1795,7 @@
                 "description": "",
                 "query": {
                     "command": "edit",
-                    "user" : { "...":"..." },
+                    "apikey" : "...",
                     "constellationid": 76813079
                 },
                 "response":{
@@ -2420,10 +2376,7 @@
                 "type": "Object",
                 "description": "Resource object to write to SNAC, with \"operation\" set to \"insert\"."
             },
-            "user" : {
-                "type": "Object",
-                "description" : "Acting user object"
-            }
+            "apikey" : "...",
         },
         "returns" : {
             "resource": {
@@ -2464,7 +2417,7 @@
                         },
                         "operation": "insert"
                     },
-                    "user": {"...":"..."}
+                    "apikey" : "...",
                 },
                 "response":{
                     "resource": {
@@ -3238,10 +3191,7 @@
         "description": "Links a constellation to an external identity on sites such as Wikipedia, VIAF, etc.",
         "category": "modification",
         "parameters" : {
-            "user" : {
-                "type": "Object",
-                "description": "User object"
-            },
+            "apikey" : "...",
             "constellationid" : {
                 "type": "Integer",
                 "description": "Constellation ID"
@@ -3259,7 +3209,7 @@
                    "command" : "add_sameas",
                    "constellationid" : 73093297,
                    "sameas_uris": ["https://en.wikipedia.org/wiki/Franciscus_Gomarus", "https://id.loc.gov/authorities/names/nb98048106"],
-                   "user" : { "...":"..." }
+                   "apikey" : "...",
                 },
                 "response":{
                     "constellation": {

--- a/src/snac/client/util/ServerConnect.php
+++ b/src/snac/client/util/ServerConnect.php
@@ -202,4 +202,19 @@ class ServerConnect {
 
         return false;
     }
+
+    public function reloadUser() {
+        $ask = array("command"=>"user_information"
+        );
+        $this->logger->addDebug("Sending user information query to the server", $ask);
+        $serverResponse = $this->query($ask);
+        $this->logger->addDebug("Received server response", array($serverResponse));
+
+        if (isset($serverResponse["user"]) && $serverResponse["user"] != null) {
+            $tmpUser = new \snac\data\User($serverResponse["user"]);
+            if ($tmpUser != null) {
+                $this->user = $tmpUser;
+            }
+        }
+    }
 }

--- a/src/snac/client/util/ServerConnect.php
+++ b/src/snac/client/util/ServerConnect.php
@@ -203,6 +203,13 @@ class ServerConnect {
         return false;
     }
 
+    /**
+     * Reload User
+     *
+     * Queries the server for the newest version of the currently logged-in user
+     * by requesting user_information.  This can be helpful if API keys are updated,
+     * messaging counts are updated, etc.
+     */
     public function reloadUser() {
         $ask = array("command"=>"user_information"
         );

--- a/src/snac/client/webui/WebUI.php
+++ b/src/snac/client/webui/WebUI.php
@@ -229,8 +229,6 @@ class WebUI implements \snac\interfaces\ServerInterface {
             // Create the PHP User object
             // $user = $executor->createUser($ownerDetails, $token);
 
-            // Set the user information into the display object
-            $display->setUserData($user->toArray());
 
             // Pull out permissions from the $user object and make them available to the template. This could
             // be done faster by storing them in the session variables along with the user object
@@ -240,8 +238,6 @@ class WebUI implements \snac\interfaces\ServerInterface {
                     $permissions[str_replace(" ", "", $privilege->getLabel())] = true;
                 }
             }
-            // NOTE: For use in Twig, the spaces HAVE BEEN REMOVED from the permission labels
-            $display->setPermissionData($permissions);
 
             // Set the user information into the executor and server connection object
             $executor->setUser($user);
@@ -666,8 +662,15 @@ class WebUI implements \snac\interfaces\ServerInterface {
         // ServerConnect utility now checks for the user object and updates its copy with the one
         // returned from the server rather than keeping the initial one sent by WebUI when the
         // ServerConnect object was created.
-        if ($executor->getUser() != null)
+        if ($executor->getUser() != null) {
             $_SESSION['snac_user'] = serialize($executor->getUser());
+        
+            // Set the user information into the display object
+            $display->setUserData($executor->getUser()->toArray());
+
+            // NOTE: For use in Twig, the spaces HAVE BEEN REMOVED from the permission labels
+            $display->setPermissionData($executor->getPermissionData());
+        }
 
         // If the display has been given a template, then use it.  Else, print out JSON.
         if ($display->hasTemplate()) {

--- a/src/snac/client/webui/WebUI.php
+++ b/src/snac/client/webui/WebUI.php
@@ -657,7 +657,8 @@ class WebUI implements \snac\interfaces\ServerInterface {
         }
 
 
-        // The server will always return a newer version of the user.  So in this case, we'll always
+        // The server MAY return a newer version of the user, or the WebUI may request
+        // an updated version of the user through its processes.  So in this case, we'll always
         // serialize to the session the latest version of the user returned to the web ui.  The
         // ServerConnect utility now checks for the user object and updates its copy with the one
         // returned from the server rather than keeping the initial one sent by WebUI when the

--- a/src/snac/client/webui/WebUI.php
+++ b/src/snac/client/webui/WebUI.php
@@ -446,7 +446,7 @@ class WebUI implements \snac\interfaces\ServerInterface {
                 $executor->displayProfilePage($display);
                 break;
             case "api_key":
-                $executor->displayAPIInfoPage($display, $user);
+                $executor->displayAPIInfoPage($this->input, $display, $user);
                 break;
             case "api_help":
                 $executor->displayAPIHelpPage($display, $user);

--- a/src/snac/client/webui/WebUIExecutor.php
+++ b/src/snac/client/webui/WebUIExecutor.php
@@ -2222,24 +2222,38 @@ class WebUIExecutor {
     }
 
     /**
-     * Display API Info Page
+     * Display API Key Management 
      *
      * Fills the display with the API information page for the given user.
      *
      * @param \snac\client\webui\display\Display $display The display object for page creation
      * @param \snac\data\User $user The current user object
      */
-    public function displayAPIInfoPage(&$display, &$user) {
-        $display->setTemplate("api_info_page");
-        $smallUser = new \snac\data\User();
-        $smallUser->setUserID($user->getUserID());
-        $smallUser->setUserName($user->getUserName());
-        $smallUser->setFullName($user->getFullName());
-        $smallUser->setToken($user->getToken());
-        $display->setData([
-            "restURL" => \snac\Config::$REST_URL,
-            "user" => json_encode($smallUser->toArray(), JSON_PRETTY_PRINT)
-        ]);
+    public function displayAPIInfoPage(&$input, &$display, &$user) {
+        $command = "view";
+        if (isset($input["subcommand"])) 
+            $command = $input["subcommand"];
+        switch($command) {
+            case "generate":
+                $display->setTemplate("api_key_generate");
+                $ask = array("command"=>"generate_key_user");
+                $this->logger->addDebug("Sending query to the server", $ask);
+                $serverResponse = $this->connect->query($ask);
+                $this->logger->addDebug("Received server response", [$serverResponse]);
+                $this->logger->addDebug("Setting api key data into the page template");
+                $display->setData($serverResponse);
+                $this->logger->addDebug("Finished setting api key data into the page template");
+                break;
+            case "revoke":
+
+                break;
+            default:   
+                $display->setTemplate("api_keys");
+                $display->setData([
+                    "restURL" => \snac\Config::$REST_URL,
+                    "user" => json_encode($user->toArray(), JSON_PRETTY_PRINT)
+                ]);
+        }
     }
 
     /**

--- a/src/snac/client/webui/WebUIExecutor.php
+++ b/src/snac/client/webui/WebUIExecutor.php
@@ -86,6 +86,13 @@ class WebUIExecutor {
         return $this->connect->getUser();
     }
 
+    /**
+     * Reload User
+     *
+     * Ask the server connector to reload the user from the server.  This will
+     * generate a user_information call to the server to get the newest version
+     * of the user object.
+     */
     public function reloadUser() {
         $this->connect->reloadUser();
     }
@@ -103,6 +110,15 @@ class WebUIExecutor {
         $this->permissions = $data;
     }
 
+    /**
+     * Get User Permissions Data
+     *
+     * Gets the permissions bitfield (as an associative array) for the user connected
+     * to this session. To maintain compatibility with Twig and other client-side scripts,
+     * permission/privielege labels have spaces and special characters removed.
+     *
+     * @return boolean[] Associative array of Permission to boolean flag
+     */
     public function getPermissionData() {
         return $this->permissions;
     }
@@ -2231,8 +2247,10 @@ class WebUIExecutor {
     /**
      * Display API Key Management 
      *
-     * Fills the display with the API information page for the given user.
+     * API Key management function.  Displays the API key information page and handles subcommands
+     * for generating and revoking API keys. 
      *
+     * @param string[] $input Post/Get inputs from the webui
      * @param \snac\client\webui\display\Display $display The display object for page creation
      * @param \snac\data\User $user The current user object
      */

--- a/src/snac/client/webui/templates/api_key_generate.html
+++ b/src/snac/client/webui/templates/api_key_generate.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>API Keys - Social Networks and Archival Context</title>
+
+<!-- JQuery -->
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css" integrity="sha384-aUGj/X2zp5rLCbBxumKTCw2Z50WgIr1vs/PFN4praOTvYXWlVyh2UtNUU0KAUhAX" crossorigin="anonymous">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"></script>
+
+<!-- Select Upgrades -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2-rc.1/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2-rc.1/js/select2.min.js"></script>
+<link rel="stylesheet" href="{{control.snacURL}}/css/select2-bootstrap.min.css">
+
+
+<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
+
+
+<!-- SNAC Stylesheet -->
+<link rel="stylesheet" href="{{control.snacURL}}/css/snac.css{{control.noCache}}">
+
+<!-- SNAC includes -->
+<script src="{{control.snacURL}}/javascript/html2canvas.js{{control.noCache}}"></script>
+<script src="{{control.snacURL}}/javascript/feedback.js{{control.noCache}}"></script>
+
+</head>
+
+<body role="document">
+
+{% from 'page_navigation.html' import topNavigation,footer %}
+{{ topNavigation(X, user, permissions, control) }}
+
+
+<div class="container snac" role="main">
+
+		<h1>New API Key</h1>
+
+        <p>You have created the following API key.  Please save it to a safe place, as it is not recoverable; you will need to generate a new key.  Treat this key as if it were your password, since it will allow its user to act on your behalf in SNAC.</p>
+
+        <div class="well well-lg text-center">
+            <p><strong>{{data.key.key}}</strong></p>
+        </div>
+
+        <p>We will identify this key to you by the first few characters.  When you see it in a list, you will see the following:
+        
+        <div class="well well-lg text-center">
+            <p><strong>{{data.key.label}}</strong></p>
+        </div>
+
+        <p>This key expires: <strong>{{data.key.expires|date('Y-m-d h:ia') }}</strong>.</p>
+
+        <p class="text-center"><a href="{{control.snacURL}}/api_key" class="btn btn-info">Return to Key List</a></p>
+
+</div>
+{{ footer(X, user, permissions, control) }}
+</body>
+</html>
+

--- a/src/snac/client/webui/templates/api_keys.html
+++ b/src/snac/client/webui/templates/api_keys.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>API Keys - Social Networks and Archival Context</title>
+
+<!-- JQuery -->
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap-theme.min.css" integrity="sha384-aUGj/X2zp5rLCbBxumKTCw2Z50WgIr1vs/PFN4praOTvYXWlVyh2UtNUU0KAUhAX" crossorigin="anonymous">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"></script>
+
+<!-- Select Upgrades -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2-rc.1/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.2-rc.1/js/select2.min.js"></script>
+<link rel="stylesheet" href="{{control.snacURL}}/css/select2-bootstrap.min.css">
+
+
+<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
+<script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"></script>
+
+
+<!-- SNAC Stylesheet -->
+<link rel="stylesheet" href="{{control.snacURL}}/css/snac.css{{control.noCache}}">
+
+<!-- SNAC includes -->
+<script src="{{control.snacURL}}/javascript/html2canvas.js{{control.noCache}}"></script>
+<script src="{{control.snacURL}}/javascript/feedback.js{{control.noCache}}"></script>
+
+</head>
+
+<body role="document">
+
+{% from 'page_navigation.html' import topNavigation,footer %}
+{{ topNavigation(X, user, permissions, control) }}
+
+
+<div class="container snac" role="main">
+
+		<h1>API Connection Information</h1>
+
+        <p>The SNAC {{control.interfaceVersion}} RestAPI is available at the following URL.</p>
+
+        <div class="well well-lg text-center">
+            <p><strong>{{data.restURL}}</strong></p>
+        </div>
+
+        <p>Rest API commands are documented <a href="{{control.snacURL}}/api_help">here</a>.  To perform any actions requiring a log-in, i.e. anything that affects change to the system, you must use an API key.  API keys are available for any user, they expire after 1 year, and allows the ...</p>
+
+        {% if user.apikeys|length > 0 %}
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>API Key Name</th>
+                    <th>Generated</th>
+                    <th>Expires</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for key in user.apikeys %}
+            <tr>
+                <td><p>{{ key.label }}</p></td>
+                <td><p>{{ key.generated|date('Y-m-d h:ia') }}</p></td>
+                <td><p>{{ key.expires|date('Y-m-d h:ia') }}</p></td>
+                <td><p><a href="#" class="btn btn-xs btn-danger">Revoke</a></p></td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="text-center" style="font-weight: bold;">You have no API keys at this time</p>
+        {% endif %}
+
+
+        <p class="text-center">
+        <a href="{{control.snacURL}}/api_key/generate" class="btn btn-success"><i class="fa fa-fw fa-plus"></i>  Generate New Key</a>
+        </p>
+
+</div>
+{{ footer(X, user, permissions, control) }}
+</body>
+</html>
+

--- a/src/snac/client/webui/templates/api_keys.html
+++ b/src/snac/client/webui/templates/api_keys.html
@@ -55,6 +55,11 @@
 
         <p>Rest API commands are documented <a href="{{control.snacURL}}/api_help">here</a>.  To perform any actions requiring a log-in, i.e. anything that affects change to the system, you must use an API key.  API keys are available for any user, they expire after 1 year, and allows the ...</p>
 
+        <h2>Your API Keys</h2>
+        {% if data.message %}
+        <p class="alert alert-warning">{{data.message|raw}}</p>
+        {% endif %}
+
         {% if user.apikeys|length > 0 %}
         <table class="table">
             <thead>
@@ -71,7 +76,7 @@
                 <td><p>{{ key.label }}</p></td>
                 <td><p>{{ key.generated|date('Y-m-d h:ia') }}</p></td>
                 <td><p>{{ key.expires|date('Y-m-d h:ia') }}</p></td>
-                <td><p><a href="#" class="btn btn-xs btn-danger">Revoke</a></p></td>
+                <td><p><a href="{{control.snacURL}}/api_key/revoke?label={{key.label}}" class="btn btn-xs btn-danger">Revoke</a></p></td>
             </tr>
             {% endfor %}
             </tbody>

--- a/src/snac/data/APIKey.php
+++ b/src/snac/data/APIKey.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * API Key for user
+ *
+ * API key information 
+ *
+ * @author Robbie Hott 
+ * @license https://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ * @copyright 2019 the Rector and Visitors of the University of Virginia, and
+ *            the Regents of the University of California
+ */
+namespace snac\data;
+
+/**
+ * API Key class
+ *
+ */
+class APIKey extends AbstractData {
+
+    private $expires = null;
+    private $label = null;
+    private $generated = null;
+
+    /**
+     * The Key string.  It should NEVER be set except when generating the key
+     * for the first time.  Else, it should be null!
+     */
+    private $keyString = null;
+
+
+    /**
+     * Constructor
+     *
+     * @param string[][] $data The data for this object in an associative array
+     */
+    public function __construct($data=null) {
+        // Calling parent's constructor doesn't affect the execution
+        //parent::__construct($data);
+        $this->dataType = 'APIKey';
+        if ($data != null && is_array($data))
+            $this->fromArray($data);
+    }
+
+    
+    public function setLabel($lbl) {
+        $this->label = $lbl; 
+    }
+
+    public function setGenerated($gen) {
+        $this->generated = $gen; 
+    }
+
+    public function setExpires($exp) {
+        $this->expires = $exp; 
+    }
+
+    public function setKey($key) {
+        $this->keyString = $key;
+    }
+
+    public function getLabel() {
+        return $this->label;
+    }
+
+    public function getGenerated() {
+        return $this->generated;
+    }
+
+    public function getExpires() {
+        return $this->expires;
+    }
+
+    public function getKey() {
+        return $this->keyString;
+    }
+
+
+    /**
+     * Required method to convert this term structure to an array
+     *
+     * @param boolean $shorten optional Whether or not to include null/empty components
+     * @return string[][] This object as an associative array
+     */
+    public function toArray($shorten = true) {
+
+        $return = [
+            "dataType" => $this->dataType,
+            "key" => $this->keyString,
+            "label" => $this->label,
+            "generated" => $this->generated,
+            "expires" => $this->expires
+        ];
+        $return = array_merge($return, parent::toArray($shorten));
+
+        // Shorten if necessary
+        if ($shorten) {
+            $return2 = array();
+            foreach ($return as $i => $v)
+                if ($v != null && !empty($v))
+                    $return2[$i] = $v;
+            unset($return);
+            $return = $return2;
+        }
+
+        return $return;
+    }
+
+    /**
+     * Required method to import an array into this data object
+     *
+     * @param string[][] $data The data for this object in an associative array
+     */
+    public function fromArray($data) {
+
+        if (!isset($data["dataType"]) || $data["dataType"] != $this->dataType)
+            return false;
+
+        parent::fromArray($data);
+
+        if (isset($data["expires"]))
+            $this->expires = $data["expires"];
+
+        if (isset($data["generated"]))
+            $this->generated = $data["generated"];
+
+        if (isset($data["label"]))
+            $this->label = $data["label"];
+        
+        if (isset($data["key"]))
+            $this->keyString = $data["key"];
+    }
+
+}
+

--- a/src/snac/data/APIKey.php
+++ b/src/snac/data/APIKey.php
@@ -18,13 +18,26 @@ namespace snac\data;
  */
 class APIKey extends AbstractData {
 
+    /**
+     * string $expires The expiration time of this key
+     */
     private $expires = null;
+
+    /**
+     * string $label The clear-text label for this key
+     */
     private $label = null;
+
+    /**
+     * string $generated The generation time of this key
+     */
     private $generated = null;
 
     /**
-     * The Key string.  It should NEVER be set except when generating the key
+     * string $key The Key string.  It should NEVER be set except when generating the key
      * for the first time.  Else, it should be null!
+     *
+     * WARNING: This should NEVER be logged on production!
      */
     private $keyString = null;
 
@@ -42,35 +55,83 @@ class APIKey extends AbstractData {
             $this->fromArray($data);
     }
 
-    
+    /**
+     * Set Label
+     *
+     * @param string $lbl the new label value
+     */ 
     public function setLabel($lbl) {
         $this->label = $lbl; 
     }
 
+    /**
+     * Set Generated
+     * 
+     * @param string $gen The new generated time for this key
+     */
     public function setGenerated($gen) {
         $this->generated = $gen; 
     }
 
+    /**
+     * Set Expires
+     *
+     * @param string $exp The new expiration time for this key
+     */
     public function setExpires($exp) {
         $this->expires = $exp; 
     }
 
+    /**
+     * Set Key
+     *
+     * WARNING: This function should NEVER be used except when generating a
+     * key for the first time.  And then, the value of the key field should NEVER be logged.
+     *
+     * @param string $key The clear-text key
+     */
     public function setKey($key) {
         $this->keyString = $key;
     }
 
+    /**
+     * Get Label
+     *
+     * @return string The label of this key
+     */
     public function getLabel() {
         return $this->label;
     }
 
+    /**
+     * Get Generated Time
+     *
+     * @return string The generation time of this key
+     */
     public function getGenerated() {
         return $this->generated;
     }
 
+    /**
+     * Get Expiration Time
+     *
+     * @return string The expiration time of this key
+     */
     public function getExpires() {
         return $this->expires;
     }
 
+    /**
+     * Get Key
+     *
+     * This method returns the clear text value of the key.  It should rarely be set.
+     *
+     * WARNING: This method should NEVER be used except on key generation.  In all other
+     * circumstances, the key field MUST be null.  The return value of this method
+     * must NEVER be logged on production.
+     *
+     * @return string The API key in clear-text
+     */
     public function getKey() {
         return $this->keyString;
     }

--- a/src/snac/data/User.php
+++ b/src/snac/data/User.php
@@ -128,6 +128,12 @@ class User implements \Serializable {
     private $active = false;
 
     /**
+     * API keys
+     * @var snac\data\APIKey[] Api Key info
+     */
+    private $apikeys = null;
+
+    /**
      * Constructor
      *
      * @param string[] $data Array object of User information
@@ -135,6 +141,7 @@ class User implements \Serializable {
     public function __construct($data = null) {
 
         $this->roleList = array();
+        $this->apikeys = array();
         if ($data != null)
             $this->fromArray($data);
     }
@@ -209,11 +216,6 @@ class User implements \Serializable {
      */
     public function setRoleList($roleList)
     {
-        /*
-         * Interesting that we set the whole list at once, and don't use addRole() (which doesn't exist) or
-         * something like that. That is probably due to writing user role links to the db, then getting back the
-         * whole role list from the db.
-         */
         $this->roleList = $roleList;
     }
 
@@ -226,6 +228,39 @@ class User implements \Serializable {
      */
     public function addRole($role) {
         array_push($this->roleList, $role);
+    }
+
+    /**
+     * Get the list of API Keys 
+     *
+     * Return the api key list
+     *
+     * @return snac\data\APIKey[] a list of APIKey objects
+     */
+    public function getAPIKeyList()
+    {
+        return $this->apikeys;
+    }
+
+    /**
+     * Set API Key list
+     *
+     * @param \snac\data\APIKey[] $keyList A list of API Keys.
+     */
+    public function setAPIKeyList($keyList)
+    {
+        $this->apikeys = $keyList;
+    }
+
+    /**
+     * Add an API Key
+     *
+     * Adds an API Key to this User.
+     *
+     * @param \snac\data\APIKey $key The API key to add to this user
+     */
+    public function addAPIKey($key) {
+        array_push($this->apikeys, $key);
     }
 
 
@@ -551,12 +586,15 @@ class User implements \Serializable {
                 "active" => $this->active,
                 "affiliation" => $this->affiliation==null?null:$this->affiliation->toArray($shorten),
                 "token" => $this->token,
-                "roleList" => array()
+                "roleList" => array(),
+                "apikeys" => array()
         );
 
         foreach ($this->roleList as $i => $v)
             $return["roleList"][$i] = $v->toArray($shorten);
 
+        foreach ($this->apikeys as $i => $v)
+            $return["apikeys"][$i] = $v->toArray($shorten);
 
         // Shorten if necessary
         if ($shorten) {
@@ -606,6 +644,15 @@ class User implements \Serializable {
             foreach ($data["roleList"] as $i => $entry) {
                 if ($entry != null)
                     $this->roleList[$i] = new \snac\data\Role($entry);
+            }
+        }
+        
+        unset($this->apikeys);
+        $this->apikeys = array();
+        if (isset($data["apikeys"])) {
+            foreach ($data["apikeys"] as $i => $entry) {
+                if ($entry != null)
+                    $this->apikeys[$i] = new \snac\data\APIKey($entry);
             }
         }
 

--- a/src/snac/server/Server.php
+++ b/src/snac/server/Server.php
@@ -95,7 +95,11 @@ class Server implements \snac\interfaces\ServerInterface {
 
         $db = new \snac\server\database\DBUtil();
 
-        // First, authenticate the user (every time to ensure they are still valid), if user information has been supplied
+        // --------------------------
+        // Authentication
+        // --------------------------
+        // Capture any user information given to the system through inputs.  This might be the
+        // OAuth-authenticated user object or an API key.
         $user = null;
         if (isset($this->input["user"])) {
             $user = $this->input["user"];
@@ -106,7 +110,7 @@ class Server implements \snac\interfaces\ServerInterface {
             $apikey = $this->input["apikey"];
         }
 
-
+        // Executor's constructor will then handle appropriate authentication
         $executor = new \snac\server\ServerExecutor($user, $apikey);
 
 

--- a/src/snac/server/Server.php
+++ b/src/snac/server/Server.php
@@ -101,8 +101,13 @@ class Server implements \snac\interfaces\ServerInterface {
             $user = $this->input["user"];
         }
 
+        $apikey = null;
+        if (isset($this->input["apikey"])) {
+            $apikey = $this->input["apikey"];
+        }
 
-        $executor = new \snac\server\ServerExecutor($user);
+
+        $executor = new \snac\server\ServerExecutor($user, $apikey);
 
 
         $this->logger->addDebug("Switching on command");
@@ -149,6 +154,8 @@ class Server implements \snac\interfaces\ServerInterface {
 
             // User Management
             case "user_information":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->userInformation();
                 break;
             case "institution_information":
@@ -157,38 +164,54 @@ class Server implements \snac\interfaces\ServerInterface {
 
 
             case "search_users":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 if (!$executor->hasPermission("Edit"))
                     throw new \snac\exceptions\SNACPermissionException("User not authorized to search users.", 403);
                 $this->response = $executor->searchUsers($this->input);
                 break;
 
             case "list_users":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 if (!$executor->hasPermission("Edit"))
                     throw new \snac\exceptions\SNACPermissionException("User not authorized to view users.", 403);
                 $this->response = $executor->listUsers($this->input);
                 break;
 
             case "user_messages":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->userMessages();
                 break;
 
             case "read_message":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->readMessage($this->input);
                 break;
 
             case "send_message":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->sendMessage($this->input);
                 break;
 
             case "archive_message":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->archiveMessage($this->input);
                 break;
 
             case "archived_messages":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->listUserArchivedMessages();
                 break;
 
             case "sent_messages":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->listUserSentMessages();
                 break;
 
@@ -197,31 +220,55 @@ class Server implements \snac\interfaces\ServerInterface {
                 break;
 
             case "edit_user":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->userInformation($this->input);
                 break;
 
             case "update_user":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->updateUserInformation($this->input);
+                break;
+
+            case "generate_key_user":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
+                $this->response = $executor->generateUserAPIKey();
+                break;
+
+            case "revoke_key_user":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
+                $this->response = $executor->revokeUserAPIKey($this->input);
                 break;
 
             // Group Management
             case "group_information":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->groupInformation($this->input);
                 break;
 
             case "admin_groups":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 if (!$executor->hasPermission("Manage Groups"))
                     throw new \snac\exceptions\SNACPermissionException("User not authorized to manage groups.", 403);
                 $this->response = $executor->listGroups($this->input);
                 break;
 
             case "edit_group":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 if (!$executor->hasPermission("Manage Groups"))
                     throw new \snac\exceptions\SNACPermissionException("User not authorized to manage groups.", 403);
                 $this->response = $executor->groupInformation($this->input);
                 break;
 
             case "update_group":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 if (!$executor->hasPermission("Manage Groups"))
                     throw new \snac\exceptions\SNACPermissionException("User not authorized to manage groups.", 403);
                 $this->response = $executor->updateGroupInformation($this->input);
@@ -229,11 +276,15 @@ class Server implements \snac\interfaces\ServerInterface {
 
             // institutions
             case "admin_institutions":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->listInstitutions();
                 break;
 
             // roles
             case "admin_roles":
+                if ($executor->isAPIKeyAuth())
+                    throw new \snac\exceptions\SNACPermissionException("Command not allowed with API key authorization.", 403);
                 $this->response = $executor->listRoles();
                 break;
 

--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -1263,7 +1263,16 @@ class ServerExecutor {
     }
 
     public function revokeUserAPIKey($input) {
-
+        $response = [
+            "result" => "failure"
+        ];
+        // can only generate an API key for logged-in users
+        if ($this->user != null && $this->user !== false && isset($input["apikey_label"])) {
+            $success = $this->uStore->revokeUserAPIKey($this->user, $input["apikey_label"]);
+            if ($success)
+                $response["result"] = "success";
+        }
+        return $response;
     }
 
 

--- a/src/snac/server/authentication/APIKeyGenerator.php
+++ b/src/snac/server/authentication/APIKeyGenerator.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * API Key Generator 
+ *
+ * @author Robbie Hott
+ * @license https://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ * @copyright 2019 the Rector and Visitors of the University of Virginia, and
+ *            the Regents of the University of California
+ */
+namespace snac\server\authentication;
+
+class APIKeyGenerator {
+
+    public static function generateKey($userid) {
+
+        $random = random_bytes(1024);
+        $time = time();
+
+        $seed = $random . $time . $userid;
+
+        $inter = sha1($seed);
+
+        $real = substr(base64_encode($inter), 0, -2);
+
+        return $real;
+    }
+
+}
+
+

--- a/src/snac/server/authentication/APIKeyGenerator.php
+++ b/src/snac/server/authentication/APIKeyGenerator.php
@@ -10,8 +10,24 @@
  */
 namespace snac\server\authentication;
 
+/**
+ * API Generator Class
+ *
+ * Static methods to generate secure API keys
+ */
 class APIKeyGenerator {
 
+    /**
+     * Generate API Key
+     *
+     * This method generates an API key by sampling random bytes, combined with the
+     * time and userID to produce a unique string that is then hashed and base64-encoded
+     * to produce a unique key.  This is essentially a long password and should NOT be stored
+     * locally.
+     *
+     * @param int $userid The user's id
+     * @return string The generated API key
+     */
     public static function generateKey($userid) {
 
         $random = random_bytes(1024);

--- a/src/snac/server/database/DBUser.php
+++ b/src/snac/server/database/DBUser.php
@@ -722,6 +722,12 @@ class DBUser
 
         return null;
     }
+    
+    public function revokeUserAPIKey($user, $label) {
+        $this->logger->addDebug("Attempting to revoke key for user", [$label]);
+        $success = $this->sql->revokeUserKey($user->getUserID(), $label);
+        return $success;
+    }
 
     public function authenticateUserByAPIKey($key) {
         $label = substr($key, 0, 8);

--- a/src/snac/server/database/SQL.php
+++ b/src/snac/server/database/SQL.php
@@ -979,6 +979,37 @@ class SQL
         }
         return $all;
     }
+    
+    public function revokeUserKey($appUserID, $label)
+    {
+        // Check to see if the key exists for the user first
+        $result = $this->sdb->query("select id from api_keys where uid=$1 and label=$2;", [$appUserID, $label]);
+
+        // Return only the data returned (one row);
+        $all = array();
+        while($row = $this->sdb->fetchrow($result))
+        {
+            $all = $row;
+        }
+
+        // If key exists for the user, then delete it
+        if (!empty($all) && isset($all["id"])) {
+            $result = $this->sdb->query("delete from api_keys where id=$1 returning *;", [$all["id"]]);
+            // Return only the data returned (one row);
+            $check = array();
+            while($row = $this->sdb->fetchrow($result))
+            {
+                $check = $row;
+            }
+
+            // Sanity check: did we actually delete something?
+            if (empty($all))
+                return false;
+            return true;
+        }
+
+        return false;
+    }
 
     public function selectAPIKeyByKey($key, $label)
     {

--- a/src/virtualhosts/www/css/snac.css
+++ b/src/virtualhosts/www/css/snac.css
@@ -202,7 +202,7 @@ h1 {
     font-family: "Crimson Text";
     font-weight: 800;
     font-size: 35px;
-    line-height: .5em;
+    line-height: .35em;
 }
 .snac-fullname-header {
     font-family: Roboto;


### PR DESCRIPTION
This pull request contains significant changes to the authentication mechanism, so please review and test!

I think it fixes some of the refreshing issues of the user object in the WebUI, including allowing the WebUI to request an updated version of the user object before returning to the user.  It may fix the "message count" problem in the snac header as well.

We'll also want to verify our logging policies.  I believe that production is set to only log errors, which would exclude any logging of API keys -- the keys should never be logged on production.  The API key itself doesn't allow a user to query for user information, so that should take care of some issues.

This will require adding the table to postgres before it gets pushed to the development server.