### PR TITLE
See shared resources

### DIFF
--- a/src/snac/client/rest/commands.json
+++ b/src/snac/client/rest/commands.json
@@ -3317,18 +3317,52 @@
                    "command" : "get_holdings",
                    "constellationid" : 76778184
                    },
-                "response":{
+                "response": {
                     "resources": [{
                         "id": "7677119",
                         "title": "Report of a focused visit to Oakland Community College ...",
                         "href": "http:\/\/www.worldcat.org\/oclc\/54358612",
                         "relation_count": 2
-                        }],
+                    }],
 	                    "result": "success",
                         "timing": 792.5
-                    }
+                }
+            }
+        ]
+    },
+    "shared_resources": {
+        "title": "Shared Resources",
+        "description": "Get an array of resources related to both constellations ",
+        "category": "resource",
+        "parameters" : {
+            "icid1" : {
+                "type": "Integer",
+                "description": "Constellation ID"
+            },
+            "icid2" : {
+                "type": "Integer",
+                "description": "Constellation ID"
+            }
+        },
+        "examples" : [
+            {
+                "title": "Shared Resources",
+                "description": "Get an array of resources held by a Holding Repository",
+                "query" : {
+                   "command" : "shared_resources",
+                   "icid1" : 29260863,
+                   "icid2" : 50307952
+                },
+                "response": {
+                    "resources": [{
+                        "id": "7960925",
+                        "title": "C.S. Lewis collection. [1939].",
+                        "href": "http:\/\/www.worldcat.org\/oclc\/667850821"
+                    }],
+                        "result": "success",
+                        "timing": 792.5
+                }
             }
         ]
     }
-
 }

--- a/src/snac/client/webui/display/Display.php
+++ b/src/snac/client/webui/display/Display.php
@@ -174,7 +174,7 @@ class Display {
         $this->data["control"]["currentURL"] = $this->cleanString("https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}");
         $this->data["control"]["referringURL"] = $this->cleanString(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : "unknown");
         $this->data["control"]["snacURL"] = \snac\Config::$WEBUI_URL;
-        $this->data["control"]["snacRest"] = \snac\Config::$REST_URL;
+        $this->data["control"]["restURL"] = \snac\Config::$REST_URL;
 
         if (isset(\snac\Config::$INTERFACE_VERSION)) {
             if (\snac\Config::$INTERFACE_VERSION === "development")

--- a/src/snac/client/webui/templates/page_navigation.html
+++ b/src/snac/client/webui/templates/page_navigation.html
@@ -15,7 +15,7 @@
 
     <script>
         var snacUrl = "{{control.snacURL}}";
-        var snacRest = "{{control.restURL}}";
+        var restUrl = "{{control.restURL}}";
     </script>
 
     {% if control.interfaceVersion == "development" %}

--- a/src/snac/client/webui/templates/view_page.html
+++ b/src/snac/client/webui/templates/view_page.html
@@ -222,6 +222,22 @@ function getSharedResources(icid1, icid2) {
     })
 }
 
+function loadSharedResourcesModal(target) {
+    // grab info on clicked table row to load the Shared Resources Modal
+    var relatedConstellationName = $(target).closest('td').find('a')[0].innerHTML;
+    $(".compared-constellation-name").html(relatedConstellationName)
+    var iconClasses = ""
+    if ($(target).closest('td').find('i.fa-stack-1x').hasClass("fa-university")) {
+        iconClasses = "fa fa-university";
+    } else if ($(target).closest('td').find('i.fa-stack-1x').hasClass("fa-users")) {
+        iconClasses = "fa fa-users"
+    } else {
+        iconClasses = "fa fa-user"
+    }
+    $("#compared-constellation-icon").removeClass();
+    $("#compared-constellation-icon").addClass(iconClasses);
+};
+
 /**
  * Prevent automatic scrolling of page to anchor by browser after page load.
  */
@@ -283,7 +299,8 @@ function loadHoldings() {
                         var cell = "<a href='" + data + "'>" + data + "</a>"
                     }
                     return cell;
-                }
+                },
+                "defaultContent": ""
             },
             {
                 "data": "relation_count"
@@ -575,28 +592,10 @@ $(document).ready(function() {
     })
 
     $("#relation-table").on("click", "a[href='#relations-modal']", function() {
-        debugger
         var icid1 = $("#constellationid").val();
         var icid2 = $(this).closest('tr').data('id');
         getSharedResources(icid1, icid2);
-
-        var relatedConstellationName = $(this).closest('td').find('a')[0].innerHTML;
-        // var relatedConstellationIcon =
-        $(".compared-constellation-name").html(relatedConstellationName)
-        // $("#shared-resources-table").find('th').last().html(relatedConstellationName)
-
-        var iconClasses = ""
-        if ($(this).closest('td').find('i.fa-stack-1x').hasClass("fa-university")) {
-            iconClasses = "fa fa-university";
-
-        } else if ($(this).closest('td').find('i.fa-stack-1x').hasClass("fa-users")) {
-            iconClasses = "fa fa-users"
-        } else {
-            iconClasses = "fa fa-user"
-        }
-        $("#compared-constellation-icon").removeClass();
-        $("#compared-constellation-icon").addClass(iconClasses);
-
+        loadSharedResourcesModal(this);
     })
 
 });

--- a/src/snac/client/webui/templates/view_page.html
+++ b/src/snac/client/webui/templates/view_page.html
@@ -202,6 +202,30 @@ screen and (min-device-pixel-ratio: 1), screen and (min-resolution: 1dppx) {
 </style>
 <script>
 
+
+function getSharedResources(icid1, icid2) {
+    // $.post(snacUrl+"/vocab_administrator/search_concepts", $("#concept-search-form").serialize(), function (data) {
+
+    console.log(icid1, icid2);
+    console.log('{"command":"shared_resources", "icid1":"'+icid1+'", "icid2":"'+ icid2 + '"}')
+    $.ajax({
+        url: restUrl,
+        method: "POST",
+        data: '{"command":"shared_resources", "icid1":"'+icid1+'", "icid2":"'+ icid2 + '"}'
+    }).done(function(data) {
+        var shared = "";
+        var length =  data.resources.length;
+        for (i = 0; i < length; i++) {
+            shared += "<p> <a href='"+data.resources[i].href+"'>" +data.resources[i].title + "</a> " + data.resources[i].arcrole + " </p>"
+        }
+        console.log("shared: ", shared)
+        console.log("done")
+        $("#shared-resources").html(
+            shared || "No resources found"
+        )
+    })
+}
+
 /**
  * Prevent automatic scrolling of page to anchor by browser after page load.
  */
@@ -233,12 +257,11 @@ function holdingsTabActions() {
 function loadHoldings() {
     var constellationid = $("#constellationid").val()
     var command = '{"command":"get_holdings", "constellationid":"' + constellationid + '"}'
-    var resturl = 'http://localhost/~josephglass/snac/rest/'
 
 $("#holding-repository-table").dataTable({
     "ajax": {
         "type": "PUT",
-        "url": "http://localhost/~josephglass/snac/rest/",
+        "url": restUrl,
         "data": function(d) {
             return command;
         },
@@ -548,6 +571,12 @@ $(document).ready(function() {
         $(".relation-btn-filter").each( function() {
             $(this).removeClass('active')
         })
+    })
+
+    $("#relation-table").on("click", "a[href='#relations-modal']", function(e) {
+        var icid1 = $("#constellationid").val();
+        var icid2 = $(e.target).closest('tr').data('id');
+        getSharedResources(icid1, icid2);
     })
 
 });
@@ -876,7 +905,7 @@ $(document).ready(function() {
                                                 </thead>
                                                 <tbody>
                                                     {% for relation in data.relations %}
-                                                    <tr>
+                                                    <tr class="id" data-id="{{relation.targetConstellation}}">
                                                         <td>{{relation.type.term}}</td>
                                                         <td>
                                                             {% if relation.targetEntityType.term == 'person' %}
@@ -896,6 +925,7 @@ $(document).ready(function() {
                                                             </span>
                                                             {% endif %}
                                                             <a href="{{control.snacURL}}/view/{{relation.targetConstellation}}">{{relation.content}}</a>
+                                                            <a style="float:right;" data-toggle="modal" data-target"#relations-modal" href="#relations-modal">See how</p>
                                                         </td>
                                                         <td>
                                                             {% if relation.targetEntityType.term %}
@@ -1241,6 +1271,102 @@ $(document).ready(function() {
                          </div>
                       </div>
                    </div>
+                </div>
+
+
+                <div class="modal fade" id="relations-modal" tabindex="-1" role="dialog" aria-labelledby="relations-modal">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header primary">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="relations-modal">Relationship</h4>
+                            </div>
+                            <div class="modal-body">
+
+<!--  -->
+<!--  -->
+                                {# displayRelationship(data.constellation, maybeSame.constellation, 'not same as') #}
+                                <div class="input-group well well-sm text-center" style="width: 100%">
+                                    <div class="col-xs-2 text-center">
+                                        <p class="relation-icon">
+                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
+                                            {% if one.entityType.term == 'person' %}
+                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
+                                            {% elseif one.entityType.term == 'corporateBody' %}
+                                            <i class="fa fa-building" aria-hidden="true"></i><br/>
+                                            {% elseif one.entityType.term == 'family' %}
+                                            <i class="fa fa-users" aria-hidden="true"></i><br/>
+                                            {% endif %}
+                                        </p>
+                                        <p class="relation-icon-caption">
+                                            {{ one.nameEntries.0.original }}
+                                        </p>
+                                    </div>
+                                    <div class="col-xs-2 text-center">
+                                        <p class="relation-icon">
+                                            <i class="fa fa-long-arrow-right" aria-hidden="true"></i><br/>
+                                        </p>
+                                    </div>
+                                    <div class="col-xs-2 text-center">
+                                        <p class="relation-icon">
+                                            <i class="fa fa-book" aria-hidden="true"></i><br/>
+                                        </p>
+                                    </div>
+                                    <div class="col-xs-2 text-center">
+                                        <p class="relation-icon">
+                                            <i class="fa fa-long-arrow-left" aria-hidden="true"></i><br/>
+                                        </p>
+                                            <!-- {% if type == 'not same as' %} -->
+                                            <!-- <span class="fa-stack fa" style="vertical-align: top; line-height: 1.6em; height: auto;"> -->
+                                                 <!-- <i class="fa fa-long-arrow-right fa-stack-1x"></i> -->
+                                                 <!-- <i class="fa fa-ban fa-stack-1x text-danger"></i> -->
+                                            <!-- </span> -->
+                                            <!-- {% else %} -->
+                                            <!-- <i class="fa fa-long-arrow-right" aria-hidden="true"></i><br/> -->
+                                            <!-- {% endif %} -->
+                                        <!-- </p> -->
+                                        <p class="relation-icon-caption" id="constellationRelation_relationPictureArrow_{{i}}">
+                                            {{type}}
+                                        </p>
+
+                                    </div>
+                                    <div class="col-xs-2 text-center">
+                                        <p class="relation-icon">
+                                            <!-- TODO: Extract a macro for CPF to icons -->
+                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
+                                            {% if two.entityType.term == 'person' %}
+                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
+                                            {% elseif two.entityType.term == 'corporateBody' %}
+                                            <i class="fa fa-building" aria-hidden="true"></i><br/>
+                                            {% elseif two.entityType.term == 'family' %}
+                                            <i class="fa fa-users" aria-hidden="true"></i><br/>
+                                            {% endif %}
+                                        </p>
+                                        <p class="relation-icon-caption">
+                                            {{ two.nameEntries.0.original }}
+                                        </p>
+                                    </div>
+                                </div>
+
+<!--  -->
+<!--  -->
+                                <p style="margin-bottom: 20px;">Shared Resources</p>
+                                <div id="shared-resources" class="">
+                                    <table>
+                                        <tr>
+
+                                        </tr>
+                                        <tr>
+                                            <td></td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                               <button type="button" data-dismiss="modal" class="btn btn-default">Close</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/snac/client/webui/templates/view_page.html
+++ b/src/snac/client/webui/templates/view_page.html
@@ -204,25 +204,21 @@ screen and (min-device-pixel-ratio: 1), screen and (min-resolution: 1dppx) {
 
 
 function getSharedResources(icid1, icid2) {
-    // $.post(snacUrl+"/vocab_administrator/search_concepts", $("#concept-search-form").serialize(), function (data) {
+    var sharedTable = $("#shared-resources-table").DataTable().clear().draw();
 
-    console.log(icid1, icid2);
-    console.log('{"command":"shared_resources", "icid1":"'+icid1+'", "icid2":"'+ icid2 + '"}')
     $.ajax({
         url: restUrl,
         method: "POST",
         data: '{"command":"shared_resources", "icid1":"'+icid1+'", "icid2":"'+ icid2 + '"}'
     }).done(function(data) {
-        var shared = "";
+        var rows = []
         var length =  data.resources.length;
         for (i = 0; i < length; i++) {
-            shared += "<p> <a href='"+data.resources[i].href+"'>" +data.resources[i].title + "</a> " + data.resources[i].arcrole + " </p>"
+            var row = [data.resources[i].arcrole_1, "<a href='"+data.resources[i].href+"'>" +data.resources[i].title + "</a> ", data.resources[i].arcrole_1]
+            rows.push(row)
         }
-        console.log("shared: ", shared)
-        console.log("done")
-        $("#shared-resources").html(
-            shared || "No resources found"
-        )
+        sharedTable.rows.add(rows).draw()
+
     })
 }
 
@@ -258,42 +254,47 @@ function loadHoldings() {
     var constellationid = $("#constellationid").val()
     var command = '{"command":"get_holdings", "constellationid":"' + constellationid + '"}'
 
-$("#holding-repository-table").dataTable({
-    "ajax": {
-        "type": "PUT",
-        "url": restUrl,
-        "data": function(d) {
-            return command;
+    $("#holding-repository-table").DataTable({
+        "ajax": {
+            "type": "PUT",
+            "url": restUrl,
+            "data": function(d) {
+                return command;
+            },
+            "dataType": "json",
+            "dataSrc": "resources"
         },
-        "dataType": "json",
-        "dataSrc": "resources"
-    },
-    "columns": [{
-            "data": null,
-            "render": function(data, type, row, meta) {
-                var cell = data.title;
-                if (data.href) {
-                    cell += "<a target='_blank' style='float:right' href='{{control.snacURL}}/vocab_administrator/resources/" +
-                        data.id + "' title='View in SNAC'> <i class='fa fa-external-link'> </i> </a>";
+        "columns": [{
+                "data": null,
+                "render": function(data, type, row, meta) {
+                    var cell = data.title;
+                    if (data.href) {
+                        cell += "<a target='_blank' style='float:right' href='{{control.snacURL}}/vocab_administrator/resources/" +
+                            data.id + "' title='View in SNAC'> <i class='fa fa-external-link'> </i> </a>";
+                    }
+                    return cell;
                 }
-                return cell;
-            }
-        },
-        // { "data": "title"},
-        {
-            "data": "href",
-            "render": function(data, type, row, meta) {
-                if (data) {
-                    var cell = "<a href='" + data + "'>" + data + "</a>"
+            },
+            // { "data": "title"},
+            {
+                "data": "href",
+                "render": function(data, type, row, meta) {
+                    if (data) {
+                        var cell = "<a href='" + data + "'>" + data + "</a>"
+                    }
+                    return cell;
                 }
-                return cell;
+            },
+            {
+                "data": "relation_count"
             }
-        },
-        {
-            "data": "relation_count"
-        }
-    ]
-})}
+        ]
+    })
+}
+
+
+
+
 
 var archivalTable = null;
 var lumpTable = null;
@@ -573,10 +574,29 @@ $(document).ready(function() {
         })
     })
 
-    $("#relation-table").on("click", "a[href='#relations-modal']", function(e) {
+    $("#relation-table").on("click", "a[href='#relations-modal']", function() {
+        debugger
         var icid1 = $("#constellationid").val();
-        var icid2 = $(e.target).closest('tr').data('id');
+        var icid2 = $(this).closest('tr').data('id');
         getSharedResources(icid1, icid2);
+
+        var relatedConstellationName = $(this).closest('td').find('a')[0].innerHTML;
+        // var relatedConstellationIcon =
+        $(".compared-constellation-name").html(relatedConstellationName)
+        // $("#shared-resources-table").find('th').last().html(relatedConstellationName)
+
+        var iconClasses = ""
+        if ($(this).closest('td').find('i.fa-stack-1x').hasClass("fa-university")) {
+            iconClasses = "fa fa-university";
+
+        } else if ($(this).closest('td').find('i.fa-stack-1x').hasClass("fa-users")) {
+            iconClasses = "fa fa-users"
+        } else {
+            iconClasses = "fa fa-user"
+        }
+        $("#compared-constellation-icon").removeClass();
+        $("#compared-constellation-icon").addClass(iconClasses);
+
     })
 
 });
@@ -1275,32 +1295,25 @@ $(document).ready(function() {
 
 
                 <div class="modal fade" id="relations-modal" tabindex="-1" role="dialog" aria-labelledby="relations-modal">
-                    <div class="modal-dialog" role="document">
+                    <div class="modal-dialog modal-lg" role="document">
                         <div class="modal-content">
                             <div class="modal-header primary">
                                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                                <h4 class="modal-title" id="relations-modal">Relationship</h4>
+                                <h4 class="modal-title" id="relations-modal"> Related Shared Resources </h4>
                             </div>
                             <div class="modal-body">
-
-<!--  -->
-<!--  -->
-                                {# displayRelationship(data.constellation, maybeSame.constellation, 'not same as') #}
                                 <div class="input-group well well-sm text-center" style="width: 100%">
                                     <div class="col-xs-2 text-center">
                                         <p class="relation-icon">
+                                            {% if data.entityType.term == "person" %}
                                             <i class="fa fa-user" aria-hidden="true"></i><br/>
-                                            {% if one.entityType.term == 'person' %}
-                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
-                                            {% elseif one.entityType.term == 'corporateBody' %}
+                                            {% elseif data.entityType.term == "corporateBody" %}
                                             <i class="fa fa-building" aria-hidden="true"></i><br/>
-                                            {% elseif one.entityType.term == 'family' %}
+                                            {% elseif data.entityType.term == "family" %}
                                             <i class="fa fa-users" aria-hidden="true"></i><br/>
                                             {% endif %}
                                         </p>
-                                        <p class="relation-icon-caption">
-                                            {{ one.nameEntries.0.original }}
-                                        </p>
+                                        <p class="relation-icon-caption"> {{ data.nameEntries.0.original }} </p>
                                     </div>
                                     <div class="col-xs-2 text-center">
                                         <p class="relation-icon">
@@ -1316,50 +1329,30 @@ $(document).ready(function() {
                                         <p class="relation-icon">
                                             <i class="fa fa-long-arrow-left" aria-hidden="true"></i><br/>
                                         </p>
-                                            <!-- {% if type == 'not same as' %} -->
-                                            <!-- <span class="fa-stack fa" style="vertical-align: top; line-height: 1.6em; height: auto;"> -->
-                                                 <!-- <i class="fa fa-long-arrow-right fa-stack-1x"></i> -->
-                                                 <!-- <i class="fa fa-ban fa-stack-1x text-danger"></i> -->
-                                            <!-- </span> -->
-                                            <!-- {% else %} -->
-                                            <!-- <i class="fa fa-long-arrow-right" aria-hidden="true"></i><br/> -->
-                                            <!-- {% endif %} -->
-                                        <!-- </p> -->
                                         <p class="relation-icon-caption" id="constellationRelation_relationPictureArrow_{{i}}">
                                             {{type}}
                                         </p>
-
                                     </div>
                                     <div class="col-xs-2 text-center">
                                         <p class="relation-icon">
-                                            <!-- TODO: Extract a macro for CPF to icons -->
-                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
-                                            {% if two.entityType.term == 'person' %}
-                                            <i class="fa fa-user" aria-hidden="true"></i><br/>
-                                            {% elseif two.entityType.term == 'corporateBody' %}
-                                            <i class="fa fa-building" aria-hidden="true"></i><br/>
-                                            {% elseif two.entityType.term == 'family' %}
-                                            <i class="fa fa-users" aria-hidden="true"></i><br/>
-                                            {% endif %}
+                                            <i id="compared-constellation-icon" class="" aria-hidden="true"></i><br/>
                                         </p>
-                                        <p class="relation-icon-caption">
-                                            {{ two.nameEntries.0.original }}
+                                        <p class="relation-icon-caption compared-constellation-name">
                                         </p>
                                     </div>
                                 </div>
-
-<!--  -->
-<!--  -->
-                                <p style="margin-bottom: 20px;">Shared Resources</p>
-                                <div id="shared-resources" class="">
-                                    <table>
-                                        <tr>
-
-                                        </tr>
-                                        <tr>
-                                            <td></td>
-                                        </tr>
-                                    </table>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <table id="shared-resources-table" class="table table-striped table-bordered table-hover dataTable no-footer" style="width:100%;">
+                                            <thead>
+                                                <tr>
+                                                    <th> {{ data.nameEntries.0.original }} </th>
+                                                    <th> Title </th>
+                                                    <th class="compared-constellation-name"></th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
                             <div class="modal-footer">

--- a/src/snac/server/Server.php
+++ b/src/snac/server/Server.php
@@ -407,6 +407,10 @@ class Server implements \snac\interfaces\ServerInterface {
                 $this->response = $executor->getHoldings($this->input);
                 break;
 
+            case "shared_resources":
+                $this->response = $executor->getSharedResources($this->input);
+                break;
+
             // Resource Management
             case "insert_resource":
                 if (!$executor->hasPermission("Edit") || !$executor->hasPermission("Create"))

--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -4135,4 +4135,32 @@ class ServerExecutor {
         return $response;
     }
 
+    /**
+     * Get Shared Resources
+     *
+     * Get array of all resources held by a Holding Institution
+     *
+     * @param string[] $input Input array from the Server object
+     * @return string[] The response to send to the client
+     */
+    public function getSharedResources(&$input) {
+        if (!isset($input["icid1"], $input["icid2"])) {
+            $response = ["result" => "failure",
+                         "error" => "Must provide constellation ids"
+                        ];
+            throw new \snac\exceptions\SNACInputException("Must provide constellation ids", 400);
+            return $response;
+        }
+
+        $this->logger->addDebug("Retrieving shared resources from Neo4J");
+
+
+        $resources = $this->neo4J->getSharedResources($input["icid1"], $input["icid2"]);
+
+        $response["resources"] = $resources;
+        $response["result"] = "success";
+
+        return $response;
+    }
+
 }

--- a/src/snac/server/neo4j/Neo4JUtil.php
+++ b/src/snac/server/neo4j/Neo4JUtil.php
@@ -870,16 +870,29 @@ class Neo4JUtil {
     * @return string[] Resources
     */
     public function getSharedResources($icid1, $icid2) {
-        $result = $this->connector->run("MATCH (:Identity {id: '{$icid1}'})-[:RRELATION]->(r:Resource)<-[rr:RRELATION]-(:Identity {id: '${icid2}'})
-        return r.id as id, r.title as title, r.href as href, rr.role as arcrole order by r.title");
+        $result = $this->connector->run("MATCH (i1:Identity {id: {icid1}})-[rr1:RRELATION]->(r:Resource)<-[rr2:RRELATION]-(i2:Identity {id: {icid2}})
+            USING INDEX i1:Identity(id) USING INDEX i2:Identity(id)
+            return r.id as id, r.title as title, r.href as href, rr1.role as arcrole_1, rr2.role as arcrole_2 order by r.title",
+            [
+                "icid1" => "{$icid1}",
+                "icid2" => "{$icid2}"
+            ]
+        );
         $resources = [];
 
         foreach ($result->getRecords() as $record) {
             $id = $record->get("id");
             $title = $record->get("title");
             $href = $record->get("href");
-            $arcrole = $record->get("arcrole");
-            $resources[] = ["id" => $id, "title" => $title, "href" => $href, "arcrole" => $arcrole];
+            $arcrole_1 = $record->get("arcrole_1");
+            $arcrole_2 = $record->get("arcrole_2");
+            $resources[] = [
+                             "id" => $id,
+                             "title" => $title,
+                             "href" => $href,
+                             "arcrole_1" => $arcrole_1,
+                             "arcrole_2" => $arcrole_2
+                            ];
         }
         return $resources;
     }

--- a/src/snac/server/neo4j/Neo4JUtil.php
+++ b/src/snac/server/neo4j/Neo4JUtil.php
@@ -860,4 +860,28 @@ class Neo4JUtil {
 
             return true;
     }
+
+    /**
+    * Get Shared Resources
+    *
+    * Given a constellation id, returns all its linked resources.
+    *
+    * @param $icid The constellation id
+    * @return string[] Resources
+    */
+    public function getSharedResources($icid1, $icid2) {
+        $result = $this->connector->run("MATCH (:Identity {id: '{$icid1}'})-[:RRELATION]->(r:Resource)<-[rr:RRELATION]-(:Identity {id: '${icid2}'})
+        return r.id as id, r.title as title, r.href as href, rr.role as arcrole order by r.title");
+        $resources = [];
+
+        foreach ($result->getRecords() as $record) {
+            $id = $record->get("id");
+            $title = $record->get("title");
+            $href = $record->get("href");
+            $arcrole = $record->get("arcrole");
+            $resources[] = ["id" => $id, "title" => $title, "href" => $href, "arcrole" => $arcrole];
+        }
+        return $resources;
+    }
+
 }

--- a/src/virtualhosts/www/javascript/concept_admin.js
+++ b/src/virtualhosts/www/javascript/concept_admin.js
@@ -52,7 +52,7 @@ function deleteTerm(event) {
             $('#success-message').slideDown();
             $('#term-modal').modal('hide');
             setTimeout(function() {
-                window.location.reload()
+                window.location.reload();
             }, 500);
         })
         .fail(function() {
@@ -123,7 +123,7 @@ function saveTermForm() {
             $('#notification-message').slideUp();
             $('#success-message').slideDown();
             setTimeout(function() {
-                window.location.reload()
+                window.location.reload();
             }, 500);
         })
         .fail(function() {
@@ -147,7 +147,7 @@ function postNewConcept() {
             $('#notification-message').slideUp();
             $('#success-message').slideDown();
             setTimeout(function() {
-                window.location = snacUrl + "/vocab_administrator/concepts/" + createdTerm.concept_id
+                window.location = snacUrl + "/vocab_administrator/concepts/" + createdTerm.concept_id;
             }, 500);
         })
         .fail(function() {
@@ -164,7 +164,7 @@ function deleteConceptRelationship() {
     var broaderID = "";
     var endpoint = "delete_broader_concepts";
     // var $secondConcept = $(event.target.parentElement);
-    var $secondConcept = $(event.target).closest('button')
+    var $secondConcept = $(event.target).closest('button');
     var secondID = $secondConcept.data("conceptId");
 
     // broader/narrower/related
@@ -205,7 +205,7 @@ function deleteConceptRelationship() {
             $('#success-message').slideDown();
             $('#term-modal').modal('hide');
             setTimeout(function() {
-                window.location.reload()
+                window.location.reload();
             }, 500);
         })
         .fail(function() {
@@ -222,7 +222,6 @@ function searchConcepts() {
 
     $("#concept-results-box").html("<p style='text-align: center'>Loading...</p>");
     $.post(snacUrl+"/vocab_administrator/search_concepts", $("#concept-search-form").serialize(), function (data) {
-    // $.post("http://localhost/~josephglass/snac/www/vocab_administrator/search_concepts?q=Flight&json=true", function(data) {
 
         var html = "";
         html += "<h4 class='text-left'>Search Results</h4><div class='list-group text-left' style='margin-bottom:0px'>";
@@ -246,7 +245,7 @@ function searchConcepts() {
 
 function postConceptRelationship() {
     var conceptID = $("#concept-id").val();
-    var relatedConceptID = $("#concept-results-box").find("input:checked").data("conceptId")
+    var relatedConceptID = $("#concept-results-box").find("input:checked").data("conceptId");
     var endpoint = "save_broader_concepts";
     var relationship = $("#concept-relationship-options").find("input:checked").val();
     var narrowerID;
@@ -272,7 +271,7 @@ function postConceptRelationship() {
         endpoint = "save_related_concepts";
         params = `?id1=${conceptID}&id2=${relatedID}`;
     }
-    console.log("Endpoint: ", endpoint + params)
+    console.log("Endpoint: ", endpoint + params);
     $.post(snacUrl + "/vocab_administrator/" + endpoint + params)
         .done(function(data) {
             createdConceptRelationship = data;
@@ -284,7 +283,7 @@ function postConceptRelationship() {
             $('#success-message').slideDown();
             $('#term-modal').modal('hide');
             setTimeout(function() {
-                window.location.reload()
+                window.location.reload();
             }, 500);
         })
         .fail(function() {
@@ -293,9 +292,9 @@ function postConceptRelationship() {
 }
 
 function describeRelation() {
-    "broader than"
-    "narrower than"
-    "related to"
+    "broader than";
+    "narrower than";
+    "related to";
 }
 
 
@@ -321,8 +320,8 @@ $('document').ready( function() {
         resetTermForm();
     });
     $("#conceptSearchPane").on("hide.bs.modal", function(event) {
-        $("#concept-results-box").html("")
-        $("#concept-searchbar").val("")
+        $("#concept-results-box").html("");
+        $("#concept-searchbar").val("");
     });
 
 });


### PR DESCRIPTION
This branch adds a Shared Resources modal which displays resources in common between two constellations. Depending on editors' interests, we might want to later add a full page that displays resources and relationships in common, as well as stats like the percentage overlap in relations or info about their respective holding institutions. 

This PR also fixes a bug with the Holding tab load.