### PR TITLE
Neo4 j bugfix

### DIFF
--- a/src/snac/data/AbstractData.php
+++ b/src/snac/data/AbstractData.php
@@ -511,7 +511,7 @@ abstract class AbstractData implements \Serializable {
             }
         }
         if (isset($this->snacControlMetadata) && $this->snacControlMetadata !== null) {
-            foreach ($this->snacControlMetadata as &$scm) {
+            foreach ($this->snacControlMetadata as $scm) {
                 $newSCM = new \snac\data\SNACControlMetadata($scm->toArray());
 
                 //TODO might be useful to have a toString() that would convert this data object into

--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -3584,14 +3584,14 @@ class ServerExecutor {
 
         $results = $this->cStore->browseNameIndex($term, $position, $entityType, $icid);
 
-        foreach ($results as &$result) {
+        foreach ($results as $k => $result) {
             $constellation = new \snac\data\Constellation();
             $constellation->setID($result["ic_id"]);
             if (\snac\Config::$USE_NEO4J) {
                 $this->neo4J->checkHoldingInstitutionStatus($constellation);
             }
             if ($constellation->hasFlag("holdingRepository"))
-                $result["entity_type"] = "holdingRepository";
+                $results[$k]["entity_type"] = "holdingRepository";
         }
 
         $response["results"] = $results;

--- a/src/snac/server/elastic/ElasticSearchUtil.php
+++ b/src/snac/server/elastic/ElasticSearchUtil.php
@@ -909,6 +909,8 @@ class ElasticSearchUtil {
                 if (isset($hit["_type"]))
                     unset($hit["_type"]);
             }
+            // be safe with pass by reference foreach
+            unset($hit);
         }
 
         return $results;

--- a/src/snac/server/identityReconciliation/ReconciliationEngine.php
+++ b/src/snac/server/identityReconciliation/ReconciliationEngine.php
@@ -269,6 +269,8 @@ class ReconciliationEngine {
             foreach ($all as $test => $result)
                 $v->setScore($test, $result);
         }
+        // Be correct with foreach pass by reference
+        unset($v);
     }
 
     /**

--- a/src/snac/server/neo4j/Neo4JUtil.php
+++ b/src/snac/server/neo4j/Neo4JUtil.php
@@ -126,10 +126,10 @@ class Neo4JUtil {
             );
 
             // List out relations
-            $rels = array();
+            $icRels = array();
             foreach ($result->getRecords() as $record) {
                 $path = $record->pathValue("p");
-                array_push($rels, [
+                array_push($icRels, [
                     "arcrole" => $path->relationships()[0]->hasValue('arcrole') ? $path->relationships()[0]->value('arcrole') : null,
                     "id" => $path->relationships()[0]->hasValue('id') ? $path->relationships()[0]->value('id') : null,
                     "version" => $path->relationships()[0]->hasValue('version') ? $path->relationships()[0]->value('version') : null,
@@ -140,27 +140,27 @@ class Neo4JUtil {
             }
 
             $this->logger->addDebug("Reconciling Relationships to Current IC");
-            $relsToDelete = array();
-            $relsToModify = array();
+            $icRelsToDelete = array();
+            $icRelsToModify = array();
             foreach($constellation->getRelations() as $relation) {
                 $add = true;
-                foreach ($rels as &$rel) {
-                    if ($relation->getTargetConstellation() == $rel["target"]) {
+                foreach ($icRels as &$icRel) {
+                    if ($relation->getTargetConstellation() == $icRel["target"]) {
                         // if it's been found, then don't add it to the index
                         $add = false;
-                        if ($relation->getType() && $relation->getVersion() != $rel["version"]) {
-                            $rel["arcrole"] = $relation->getType() ? $relation->getType()->getTerm() : "";
-                            $rel["id"] = $relation->getID();
-                            $rel["version"] = $relation->getVersion();
-                            $rel["operation"] = "update";
+                        if ($relation->getType() && $relation->getVersion() != $icRel["version"]) {
+                            $icRel["arcrole"] = $relation->getType() ? $relation->getType()->getTerm() : "";
+                            $icRel["id"] = $relation->getID();
+                            $icRel["version"] = $relation->getVersion();
+                            $icRel["operation"] = "update";
                         } else {
-                            $rel["operation"] = null;
+                            $icRel["operation"] = null;
                         }
                         break;
                     }
                 }
                 if ($add)
-                    array_push($rels, [
+                    array_push($icRels, [
                         "target" => $relation->getTargetConstellation(),
                         "id" => $relation->getID(),
                         "version" => $relation->getVersion(),
@@ -168,14 +168,14 @@ class Neo4JUtil {
                         "operation" => "insert"
                     ]);
             }
-            $this->logger->addDebug("List of related identity paths", $rels);
+            $this->logger->addDebug("List of related identity paths", $icRels);
 
             // Make the relationship changes
-            foreach ($rels as $rel) {
+            foreach ($icRels as $rel) {
                 switch($rel["operation"]) {
                     case "insert":
                         $result = $this->connector->run("MATCH (a:Identity {id: {id1} }),(b:Identity {id: {id2} })
-                                                            CREATE (a)-[r:ICRELATION {infos}]->(b)",
+                                                            CREATE (a)-[r:ICRELATION {infos}]->(b);",
                         [
                             'id1' => $constellation->getID(),
                             'id2' => $rel["target"],
@@ -214,6 +214,7 @@ class Neo4JUtil {
             // ************************************
             // STEP 3: Check all the resource relations. Update, insert, or delete as appropriate
             $this->logger->addDebug("Reading resource relationships from Neo4J");
+            $rRels = array();
             try {
                 $result = $this->connector->run("MATCH p=(a:Identity {id: {icid} })-[r:RRELATION]->(b:Resource) return p;",
                     [
@@ -222,10 +223,9 @@ class Neo4JUtil {
                 );
 
                 // List out relations
-                $rels = array();
                 foreach ($result->getRecords() as $record) {
                     $path = $record->pathValue("p");
-                    array_push($rels, [
+                    array_push($rRels, [
                         "target" => $path->end()->value("id"),
                         "role" => $path->relationships()[0]->hasValue('role') ? $path->relationships()[0]->value('role') : null,
                         "id" => $path->relationships()[0]->hasValue('id') ? $path->relationships()[0]->value('id') : null,
@@ -239,26 +239,26 @@ class Neo4JUtil {
                 throw $e;
             }
             $this->logger->addDebug("Reconciling Resource Relationships to Current IC");
-            $relsToDelete = array();
-            $relsToModify = array();
+            $rRelsToDelete = array();
+            $rRelsToModify = array();
             foreach($constellation->getResourceRelations() as $relation) {
                 $add = true;
-                foreach ($rels as &$rel) {
-                    if ($relation->getResource()->getID() == $rel["target"]) {
+                foreach ($rRels as &$rRel) {
+                    if ($relation->getResource()->getID() == $rRel["target"]) {
                         // if it's been found, then don't add it to the index
                         $add = false;
-                        if ($relation->getVersion() != $rel["version"]) {
-                            $rel["role"] = $relation->getRole() ? $relation->getRole()->getTerm() : "";
-                            $rel["version"] = $relation->getVersion();
-                            $rel["operation"] = "update";
+                        if ($relation->getVersion() != $rRel["version"]) {
+                            $rRel["role"] = $relation->getRole() ? $relation->getRole()->getTerm() : "";
+                            $rRel["version"] = $relation->getVersion();
+                            $rRel["operation"] = "update";
                         } else {
-                            $rel["operation"] = null;
+                            $rRel["operation"] = null;
                         }
                         break;
                     }
                 }
                 if ($add)
-                    array_push($rels, [
+                    array_push($rRels, [
                         "target" => $relation->getResource()->getID(),
                         "role" => $relation->getRole() ? $relation->getRole()->getTerm() : "",
                         "id" => $relation->getID(),
@@ -266,14 +266,14 @@ class Neo4JUtil {
                         "operation" => "insert"
                     ]);
             }
-            $this->logger->addDebug("List of related resource paths", $rels);
+            $this->logger->addDebug("List of related resource paths", $rRels);
 
             // Make the relationship changes
-            foreach ($rels as $rel) {
+            foreach ($rRels as $rel) {
                 switch($rel["operation"]) {
                     case "insert":
                         $result = $this->connector->run("MATCH (a:Identity {id: {id1} }),(b:Resource {id: {id2} })
-                                                            CREATE (a)-[r:RRELATION {infos}]->(b)",
+                                                            CREATE (a)-[r:RRELATION {infos}]->(b);",
                         [
                             'id1' => $constellation->getID(),
                             'id2' => $rel["target"],

--- a/src/snac/server/neo4j/Neo4JUtil.php
+++ b/src/snac/server/neo4j/Neo4JUtil.php
@@ -159,6 +159,9 @@ class Neo4JUtil {
                         break;
                     }
                 }
+                // Be correct with pass by reference foreach loops
+                unset($icRel);
+                
                 if ($add)
                     array_push($icRels, [
                         "target" => $relation->getTargetConstellation(),
@@ -257,6 +260,9 @@ class Neo4JUtil {
                         break;
                     }
                 }
+                // Be correct with pass by reference foreach loops
+                unset($rRel);
+
                 if ($add)
                     array_push($rRels, [
                         "target" => $relation->getResource()->getID(),

--- a/src/virtualhosts/openrefine/index.php
+++ b/src/virtualhosts/openrefine/index.php
@@ -34,6 +34,8 @@ try {
         if ($decode = json_decode($part, true))
             $part = $decode;
     }
+    // Be correct with foreach pass by reference
+    unset($part);
     
     // Instantiate and run the server
     $server = new OpenRefine($input);


### PR DESCRIPTION
PHP is unsafe with foreach with pass by reference.  This bugfix removes uses of variables after they've been used as a reference in a foreach.  It also calls unset() to remove the reference variable so it can be used later on.