### PR TITLE
Improves the Send for Review form.

### DIFF
--- a/src/snac/client/webui/templates/_send_review_pane.html
+++ b/src/snac/client/webui/templates/_send_review_pane.html
@@ -1,0 +1,34 @@
+    <div class="modal fade" id="sendReviewPane" tabindex="-1" role="dialog" aria-labelledby="sendReviewPane">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header primary">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="sendReviewPaneLabel">Send for Review Options</h4>
+                </div>
+                <div class="modal-body" id="sendReviewPaneContent">
+                        <div class="modal-body">
+                            <div style="margin-top: 20px;">
+                                <textarea id="sendReviewMessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
+                            </div>
+                            <p>Search for a User's name or primary email address below to send this constellation to that person
+                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
+                            <div style="margin-top: 20px;">
+                                <select class="form-control" id="reviewersearchbox">
+                                    <option></option>
+                                </select>
+                            </div>
+
+                            <div id="user-results-box">
+                            </div>
+                            <div style="text-align: center; margin-top: 10px;">
+                                <button type="button" class="btn btn-default" id="save_and_review_general" data-dismiss="modal">Send to General Reviewer Pool</button>
+                                <button type="button" class="btn btn-success" id="save_and_review_touser" data-dismiss="modal">Send Review</button>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Cancel</span></button>
+                </div>
+            </div>
+        </div>
+    </div>

--- a/src/snac/client/webui/templates/dashboard.html
+++ b/src/snac/client/webui/templates/dashboard.html
@@ -286,44 +286,7 @@ $.fn.modal.Constructor.prototype.enforceFocus = $.noop;
 </div>
 
 <form id="send_review_form">
-    <div class="modal fade" id="sendReviewPane" tabindex="-1" role="dialog" aria-labelledby="sendReviewPane">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header primary">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="sendReviewPaneLabel">Send for Review Options</h4>
-                </div>
-                <div class="modal-body" id="sendReviewPaneContent">
-                        <div class="modal-body">
-                            <p>Search for a User's name or primary email address below to send this constellation to that person
-                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
-                            <div class="input-group select2-bootstrap-append">
-                                <select class="form-control"
-                                    placeholder="Name or Email..." id="reviewersearchbox">
-                                    <option></option>
-                                </select>
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-primary" id="save_and_review_touser" data-dismiss="modal">Send for Review</button>
-                                </span>
-                            </div>
-
-                            <div id="user-results-box">
-                            </div>
-                            <div style="text-align: center; margin-top: 10px;">
-                                <p>OR</p>
-                                <button type="button" class="btn btn-success" id="save_and_review_general" data-dismiss="modal"><span class="glyphicon glyphicon-send"></span> Send to General Reviewer Pool</button>
-                            </div>
-                            <div style="margin-top: 20px;">
-                                <textarea id="reviewmessage" name="reviewmessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
-                            </div>
-                        </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Cancel</span></button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include '_send_review_pane.html' %}
 </form>
 {{ footer(X, user, permissions, control) }}
 </body>

--- a/src/snac/client/webui/templates/dashboard/editor.html
+++ b/src/snac/client/webui/templates/dashboard/editor.html
@@ -272,44 +272,7 @@ $.fn.modal.Constructor.prototype.enforceFocus = $.noop;
 </div>
 
 <form id="send_review_form">
-    <div class="modal fade" id="sendReviewPane" tabindex="-1" role="dialog" aria-labelledby="sendReviewPane">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header primary">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="sendReviewPaneLabel">Send for Review Options</h4>
-                </div>
-                <div class="modal-body" id="sendReviewPaneContent">
-                        <div class="modal-body">
-                            <p>Search for a User's name or primary email address below to send this constellation to that person
-                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
-                            <div class="input-group select2-bootstrap-append">
-                                <select class="form-control"
-                                    placeholder="Name or Email..." id="reviewersearchbox">
-                                    <option></option>
-                                </select>
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-primary" id="save_and_review_touser" data-dismiss="modal">Send for Review</button>
-                                </span>
-                            </div>
-
-                            <div id="user-results-box">
-                            </div>
-                            <div style="text-align: center; margin-top: 10px;">
-                                <p>OR</p>
-                                <button type="button" class="btn btn-success" id="save_and_review_general" data-dismiss="modal"><span class="glyphicon glyphicon-send"></span> Send to General Reviewer Pool</button>
-                            </div>
-                            <div style="margin-top: 20px;">
-                                <textarea id="reviewmessage" name="reviewmessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
-                            </div>
-                        </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Cancel</span></button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include '_send_review_pane.html' %}
 </form>
 {{ footer(X, user, permissions, control) }}
 </body>

--- a/src/snac/client/webui/templates/dashboard/reporting.html
+++ b/src/snac/client/webui/templates/dashboard/reporting.html
@@ -227,44 +227,7 @@ $.fn.modal.Constructor.prototype.enforceFocus = $.noop;
 </div>
 
 <form id="send_review_form">
-    <div class="modal fade" id="sendReviewPane" tabindex="-1" role="dialog" aria-labelledby="sendReviewPane">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header primary">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="sendReviewPaneLabel">Send for Review Options</h4>
-                </div>
-                <div class="modal-body" id="sendReviewPaneContent">
-                        <div class="modal-body">
-                            <p>Search for a User's name or primary email address below to send this constellation to that person
-                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
-                            <div class="input-group select2-bootstrap-append">
-                                <select class="form-control"
-                                    placeholder="Name or Email..." id="reviewersearchbox">
-                                    <option></option>
-                                </select>
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-primary" id="save_and_review_touser" data-dismiss="modal">Send for Review</button>
-                                </span>
-                            </div>
-
-                            <div id="user-results-box">
-                            </div>
-                            <div style="text-align: center; margin-top: 10px;">
-                                <p>OR</p>
-                                <button type="button" class="btn btn-success" id="save_and_review_general" data-dismiss="modal"><span class="glyphicon glyphicon-send"></span> Send to General Reviewer Pool</button>
-                            </div>
-                            <div style="margin-top: 20px;">
-                                <textarea id="reviewmessage" name="reviewmessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
-                            </div>
-                        </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Cancel</span></button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include '_send_review_pane.html' %}
 </form>
 {{ footer(X, user, permissions, control) }}
 </body>

--- a/src/snac/client/webui/templates/edit_page.html
+++ b/src/snac/client/webui/templates/edit_page.html
@@ -505,44 +505,7 @@
         </div>
     </div>
 
-    <div class="modal fade" id="sendReviewPane" tabindex="-1" role="dialog" aria-labelledby="sendReviewPane">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header primary">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="sendReviewPaneLabel">Send for Review Options</h4>
-                </div>
-                <div class="modal-body" id="sendReviewPaneContent">
-                        <div class="modal-body">
-                            <p>Search for a User's name or primary email address below to send this constellation to that person
-                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
-                            <div class="input-group select2-bootstrap-append">
-                                <select class="form-control"
-                                    placeholder="Name or Email..." id="reviewersearchbox">
-                                    <option></option>
-                                </select>
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-primary" id="save_and_review_touser" data-dismiss="modal">Send for Review</button>
-                                </span>
-                            </div>
-
-                            <div id="user-results-box">
-                            </div>
-                            <div style="text-align: center; margin-top: 10px;">
-                                <p>OR</p>
-                                <button type="button" class="btn btn-success" id="save_and_review_general" data-dismiss="modal"><span class="glyphicon glyphicon-send"></span> Send to General Reviewer Pool</button>
-                            </div>
-                            <div style="margin-top: 20px;">
-                                <textarea id="sendReviewMessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
-                            </div>
-                        </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-danger" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">Cancel</span></button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include '_send_review_pane.html' %}
 
 <div class="modal fade" id="previewPane" tabindex="-1" role="dialog" aria-labelledby="previewPane">
     <div class="modal-dialog" role="document" style="width:90%;">

--- a/src/virtualhosts/www/javascript/dashboard.js
+++ b/src/virtualhosts/www/javascript/dashboard.js
@@ -33,7 +33,7 @@ function sendForReviewModal(id, version) {
 
 function sendReview() {
     // Pull the message text
-    reviewPayload.reviewmessage = $("#reviewmessage").val();
+    reviewPayload.reviewmessage = $("#sendReviewMessage").val();
 
     // Send the browser to the review page (which will then redirect them back to the dashboard)
     window.location.href = snacUrl+"/review/"+reviewPayload.id+"/"+reviewPayload.version+"?reviewer="+reviewPayload.reviewer+"&reviewmessage="+encodeURIComponent(reviewPayload.reviewmessage);

--- a/src/virtualhosts/www/javascript/select_loaders.js
+++ b/src/virtualhosts/www/javascript/select_loaders.js
@@ -244,6 +244,7 @@ function affiliation_select_replace(selectItem) {
 function reviewer_select_replace(selectItem) {
         if(selectItem != null) {
                 selectItem.select2({
+                    placeholder: "Reviewer Name or Email...",
                     ajax: {
                         url: function() {
                             var query = snacUrl+"/user_search?role=Reviewer";


### PR DESCRIPTION
Modified the send for review form to use a twig template to avoid code
repetition.

This implied changes on the JavaScript in order to use the same field
IDs in all the places that the form was used before.

**TODO: **
+ Make the changes :
  + `dashboard.html`
  + `reporting.html`
  + `editor.html`

So all of them use the same template