### PR TITLE
Updates SameAs interface to use a control list for URIs

### DIFF
--- a/src/snac/client/webui/WebUIExecutor.php
+++ b/src/snac/client/webui/WebUIExecutor.php
@@ -3704,6 +3704,9 @@ class WebUIExecutor {
                         }
 
                         $serverResponse["results"][$k]["text"] = $serverResponse["results"][$k]["value"];
+                        if (isset($input["use_description"]) && ($input["use_description"] == 'true')) {
+                          $serverResponse["results"][$k]["text"] = $v["description"];
+                        }
                     }
                 }
 

--- a/src/snac/client/webui/languages/english.json
+++ b/src/snac/client/webui/languages/english.json
@@ -247,6 +247,14 @@
         "display" : "URI",
         "tooltip" : "The permanent link to the external identity"
     },
+    "sameAsBaseURI" : {
+        "display" : "Base URI",
+        "tooltip" : "The base domain for the external identity permanent link"
+    },
+    "sameAsURIId" : {
+        "display" : "URI identifier",
+        "tooltip" : "The identifier used in the external identity permanent link"
+    },
 
     "_comment" : "%%% EntityID elements",
 

--- a/src/snac/client/webui/templates/edit_components.html
+++ b/src/snac/client/webui/templates/edit_components.html
@@ -481,13 +481,33 @@
                             <p class="form-control-static">{{ other.uri }}</p>
                         </div>
                     </div>
+                    <div class="form-group" style="display:none" id="sameAs_baseuri_container_{{ i }}">
+                        <label for="sameAs_baseuri_{{ i }}" class="control-label col-xs-4" data-content="{{X.sameAsBaseURI.tooltip}}" data-toggle="popover" data-placement="top">
+                            {{ X.sameAsBaseURI.display }}
+                        </label>
+                        <div class="col-xs-8" id="select_sameAs_baseuri_{{i}}">
+                          <input id="sameAs_baseuri_id_{{i}}" name="sameAs_baseuri_id_{{i}}" type="hidden" class="form-control" value="{{ other.uri }}"/>
+                          <input id="sameAs_baseuri_term_{{i}}" name="sameAs_baseuri_term_{{i}}" type="hidden" class="form-control" value="{{ WorldCat }}"/>
+                          <input id="sameAs_baseuri_vocabtype_{{i}}" name="sameAs_baseuri_vocabtype_{{i}}" type="hidden" class="form-control" value="external_sameas_domain"/>
+                          <input id="sameAs_baseuri_minlength_{{i}}" name="sameAs_baseuri_minlength_{{i}}" type="hidden" class="form-control" value="0"/>
+                          <p class="form-control-static">{{ other.uri }}</p>
+                        </div>
+                    </div>
+                    <div class="form-group" style="display:none" id="sameAs_uriid_container_{{ i }}">
+                        <label for="sameAs_uriid_{{ i }}" class="control-label col-xs-4" data-content="{{X.sameAsURIId.tooltip}}" data-toggle="popover" data-placement="top">
+                            {{ X.sameAsURIId.display }}
+                        </label>
+                        <div class="col-xs-8" id="text_sameAs_uriid_{{i}}">
+                            <input id="sameAs_uriid_{{i}}" name="sameAs_uriid_{{i}}" type="hidden" class="form-control" value="{{ other.uri }}"/>
+                            <p class="form-control-static">{{ other.uri }}</p>
+                        </div>
+                    </div>
                 </div>
 
                 {{ widgets.scmModal(X, inEdit, showSubElements, "sameAs", i, other.uri, "Same-As Relation", other) }}
                 {{ widgets.optionsList(X, inEdit, showSubElements, "sameAs", i) }}
             </div>
         </div>
-
 {% endmacro %}
 
 {% macro displayEntityID(X, inEdit, showSubElements, other, i) %}

--- a/src/virtualhosts/www/javascript/edit_scripts.js
+++ b/src/virtualhosts/www/javascript/edit_scripts.js
@@ -241,6 +241,18 @@ function textToSelect(shortName, idStr) {
 
             if (name == "citation")
                 scm_source_select_replace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr);
+            else if (shortName == "sameAs" && name == "baseuri") {
+                //The following block handles the specific case of Same As External Resource association form
+                loadVocabSelectOptions($("#"+shortName+"_"+name+"_id_"+idStr), "external_sameas_domain", "Base URI", true);
+                var uriRegexp = /^(?<baseuri>.+)\/(?<uriid>.+)$/;
+                var currentURI = $("#"+shortName+"_uri_"+idStr).val();
+                if (currentURI) {
+                  var uriResult = currentURI.match(uriRegexp).groups;
+                  $("#sameAs_baseuri_id_"+idStr).val(uriResult.baseuri);
+                  $("#sameAs_uriid_"+idStr).val(uriResult.uriid);
+                }
+                $("#"+shortName+"_uri_"+idStr).prop("readonly", true);
+            }
             else
                 vocab_select_replace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr, vocabtype, minlength);
 
@@ -751,6 +763,13 @@ function subMakeEditable(short, i) {
             updatePlaceHeading(short, i,
                 $('#'+short+'_geoplace_id_'+i).val());
         });
+    }
+    // Same As add on change functions
+    if (short == 'sameAs') {
+        $("#sameAs_baseuri_id_"+i).change(updateSameAsURI);
+        $("#sameAs_baseuri_container_"+i).css("display","block");
+        $("#sameAs_uriid_"+i).on("input", updateSameAsURI);
+        $("#sameAs_uriid_container_"+i).css("display","block");
     }
 
     // add parser btn if nameEntry is a computed name, entity is person, and if no btn or extra name components already exist

--- a/src/virtualhosts/www/javascript/select_loaders.js
+++ b/src/virtualhosts/www/javascript/select_loaders.js
@@ -278,14 +278,27 @@ function select_replace_simple(selectItem) {
  *
  * Replaces the select with a select2 object preloaded with an array of options
  *
- * @param  JQuery selectItem The JQuery item to replace
- * @param  string type       The type of the vocabulary term
- * @param  string type       Text placeholder for select
+ * @param  JQuery selectItem             The JQuery item to replace
+ * @param  string type                   The type of the vocabulary term
+ * @param  string type                   Text placeholder for select
+ * @param  string [useDescription=false] Use description instead of value for text field on return object
  */
-function loadVocabSelectOptions(selectItem, type, placeholder) {
-    return $.get(snacUrl + "/vocabulary?type=" + type)
+function loadVocabSelectOptions(selectItem, type, placeholder, useDescription = false) {
+    var url = "/vocabulary?type=" + type;
+    if (useDescription == true) {
+     url = url.concat("&use_description=true");
+    }
+    return $.get(snacUrl + url)
     .done(function(data) {
         var options = data.results;
+        if (useDescription == true) {
+          options = options.reduce(function(newOptions, option){
+            var newElement = option;
+            newElement["id"] = option["value"]
+            newOptions.push(newElement);
+            return newOptions;
+          },[]);
+        }
         selectItem.select2({
             data: options,
             allowClear: false,
@@ -293,6 +306,14 @@ function loadVocabSelectOptions(selectItem, type, placeholder) {
             placeholder: placeholder
         });
     });
+}
+
+function updateSameAsURI() {
+  var id = this.id;
+  var sequence = id.match(/_(?<sequence>[0-9]+)$/).groups.sequence;
+  var baseURI = $("#sameAs_baseuri_id_"+sequence).val();
+  var uriId = $("#sameAs_uriid_"+sequence).val();
+  $("#sameAs_uri_"+sequence).val(baseURI+uriId);
 }
 
 /**


### PR DESCRIPTION
References Issue: https://github.com/snac-cooperative/snac/issues/247

We add a control list to the `vocabulary` table under the type
`external_related_resource_domains`. The interface now is broken up in
two parts a URI base and the element identifier. This change affects
only the frontend the data models for `sameAs` stays the same.

The main idea is to use the control list to prevent common mistakes when
adding data, and to standardise the resources.

The changes in this commit include changes in the `vocabulary` API. The
API used to return an JSON representation of the form:

```JSON
{
results: [
{
id: "400601",
value: "http://datos.bne.es/persona/",
text: "http://datos.bne.es/persona/"
},
{
id: "400595",
value: "http://d-nb.info/gnd/",
text: "http://d-nb.info/gnd/"
},
]
}
```

Where the value in the `text` filed was the same as the value for the
vocabulary entry. We want it to use the `description` of the vocabulary
entry as the `text`.

```JSON
[
{
id: "400601",
value: "http://datos.bne.es/persona/",
text: "National Library of Spain"
},
{
id: "400595",
value: "http://d-nb.info/gnd/",
text: "German National Library"
},
{
id: "400598",
value: "http://id.loc.gov/authorities/names/",
text: "Library of Congress/NACO"
},
]
```

To accomplish this now the API endpoint now supports a new optional
parameter `use_description` that expects a value `true` or `false`. If
the value exists and it is `true` the returned object will include the
`description`, else it'll return as before. A new call will looks like
the following:

```
http://SNAC_URL/vocabulary?type=external_related_resource_domains&use_description=true
```

Also the changes include the options for the control list to be added in
the SNAC seed data:

```
install/sql_files/vocabulary.sql
```
