### PR TITLE
Fixes Firefox regex bug for same as domain interface - quickfix

### DIFF
--- a/src/virtualhosts/www/javascript/edit_scripts.js
+++ b/src/virtualhosts/www/javascript/edit_scripts.js
@@ -245,11 +245,11 @@ function textToSelect(shortName, idStr) {
                 //The following block handles the specific case of Same As External Resource association form
                 loadVocabSelectOptions($("#"+shortName+"_"+name+"_id_"+idStr), "external_sameas_domain", "Base URI", true);
                 var currentURI = $("#"+shortName+"_uri_"+idStr).val();
+                var uriRegexp = /^(.+)\/(.+)$/;
                 if (currentURI) {
-                    var authorityBaseURI = currentURI.slice(0, currentURI.lastIndexOf('/') + 1)
-                    var authorityID = currentURI.slice(currentURI.lastIndexOf('/') + 1)
-                    $("#sameAs_baseuri_id_"+idStr).val(authorityBaseURI);
-                    $("#sameAs_uriid_"+idStr).val(authorityID);
+                    var uriResult = currentURI.match(uriRegexp);
+                    $("#sameAs_baseuri_id_"+idStr).val(uriResult[1]);
+                    $("#sameAs_uriid_"+idStr).val(uriResult[2]);
                 }
                 $("#"+shortName+"_uri_"+idStr).prop("readonly", true);
             }

--- a/src/virtualhosts/www/javascript/select_loaders.js
+++ b/src/virtualhosts/www/javascript/select_loaders.js
@@ -309,11 +309,11 @@ function loadVocabSelectOptions(selectItem, type, placeholder, useDescription = 
 }
 
 function updateSameAsURI() {
-    var id = this.id;
-    var sequence = id.slice(id.lastIndexOf('_') + 1)
-    var baseURI = $("#sameAs_baseuri_id_"+sequence).val();
-    var uriId = $("#sameAs_uriid_"+sequence).val();
-    $("#sameAs_uri_"+sequence).val(baseURI+uriId);
+  var id = this.id;
+  var sequence = id.match(/_([0-9]+)$/)[1];
+  var baseURI = $("#sameAs_baseuri_id_"+sequence).val();
+  var uriId = $("#sameAs_uriid_"+sequence).val();
+  $("#sameAs_uri_"+sequence).val(baseURI+uriId);
 }
 
 /**


### PR DESCRIPTION
Firefox didn't support the use of named groups. So the code was updated
to avoid that issue. We are now getting the matches directly from the
array of matches.