### PR TITLE
Fix login failure with capital letters bug

### DIFF
--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -169,7 +169,7 @@ class ServerExecutor {
 
             $ownerDetails = $provider->getResourceOwner($accessToken);
 
-            if ($ownerDetails->getEmail() != $user->getEmail()) {
+            if (strtolower($ownerDetails->getEmail()) != strtolower($user->getEmail())) {
                 // This user's token doesn't match the user's email
                 $this->logger->addDebug("Email mismatch from the user and OAuth details");
                 return false;

--- a/src/snac/server/database/SQL.php
+++ b/src/snac/server/database/SQL.php
@@ -519,7 +519,7 @@ class SQL
      */
     public function selectUserByEmail($email)
     {
-        $result = $this->sdb->query("select id from appuser where email=$1 limit 1",
+        $result = $this->sdb->query("select id from appuser where lower(email) = lower($1) limit 1",
                                     array($email));
         $row = $this->sdb->fetchrow($result);
         if ($row && array_key_exists('id', $row))
@@ -545,7 +545,7 @@ class SQL
      */
     public function selectUserByUserName($userName)
     {
-        $result = $this->sdb->query("select id from appuser where username=$1",
+        $result = $this->sdb->query("select id from appuser where lower(username) = lower($1)",
                                     array($userName));
         $row = $this->sdb->fetchrow($result);
         if ($row && array_key_exists('id', $row))


### PR DESCRIPTION
- Handle login with case insensitive email and username
- Lowercase the email we receive from Oauth in ServerExec
- Add case-insensitive search for email and username when selecting user from database.
- Fixes #257