### PR TITLE
Updates to same as label info changes/256/drc2r

### DIFF
--- a/src/snac/client/webui/languages/english.json
+++ b/src/snac/client/webui/languages/english.json
@@ -235,10 +235,6 @@
 
     "_comment" : "%%% SameAs elements",
 
-    "sameAsText" : {
-        "display" : "Relation Text",
-        "tooltip" : "The human-readable text that appears in a relation entry"
-    },
     "sameAsRole" : {
         "display" : "Role",
         "tooltip" : "How this Identity Constellation is related to the external identity"

--- a/src/snac/client/webui/templates/detailed_preview_page.html
+++ b/src/snac/client/webui/templates/detailed_preview_page.html
@@ -165,7 +165,7 @@ $.fn.modal.Constructor.prototype.enforceFocus = $.noop;
                     </div>
 
                     <div class="tab-pane" id="sameAs">
-                        <h2>External CPF Relations (Same As)</h2>
+                        <h2>External Related CPF</h2>
 
 
 

--- a/src/snac/client/webui/templates/detailed_view_page.html
+++ b/src/snac/client/webui/templates/detailed_view_page.html
@@ -167,7 +167,7 @@ $.fn.modal.Constructor.prototype.enforceFocus = $.noop;
                     </div>
 
                     <div class="tab-pane" id="sameAs">
-                        <h2>External CPF Relations (Same As)</h2>
+                        <h2>External Related CPF</h2>
 
 
 

--- a/src/snac/client/webui/templates/edit_components.html
+++ b/src/snac/client/webui/templates/edit_components.html
@@ -30,7 +30,7 @@
             <ul class="dropdown-menu">
                 <li><a href="#resourceRelations" id="resourceRelationstab" role="tab" data-toggle="tab">Resource Relations</a></li>
                 <li><a href="#constellationRelations" id="constellationRelationstab" role="tab" data-toggle="tab">Internal CPF Relations</a></li>
-                <li><a href="#sameAs" id="sameAstab" role="tab" data-toggle="tab">External CPF (Same As)</a></li>
+                <li><a href="#sameAs" id="sameAstab" role="tab" data-toggle="tab">External Related CPF</a></li>
                 <li><a href="#entityID" id="entityIDtab" role="tab" data-toggle="tab">Other Entity IDs (Same As)</a></li>
             </ul>
         </li>
@@ -463,15 +463,6 @@
                     <input id="sameAs_version_{{i}}" name="sameAs_version_{{i}}" type="hidden" value="{{ other.version }}"/>
                     <input id="sameAs_operation_{{i}}" name="sameAs_operation_{{i}}" type="hidden" value="{{ other.operation }}"/>
                     <input id="sameAs_type_id_{{i}}" name="sameAs_type_id_{{i}}" type="hidden" value="{{ other.type.id }}"/>
-                    <!-- <div class="form-group">
-                        <label for="sameAs_text_{{ i }}" class="control-label col-xs-4" data-content="{{X.sameAsText.tooltip}}" data-toggle="popover" data-placement="top">
-                           {{ X.sameAsText.display }}
-                        </label>
-                        <div class="col-xs-8" id="text_sameAs_text_{{i}}">
-                            <input id="sameAs_text_{{i}}" name="sameAs_text_{{i}}" type="hidden" class="form-control" value="{{ other.text }}"/>
-                            <p class="form-control-static">{{ other.text }}</p>
-                        </div>
-                    </div> -->
                     <div class="form-group">
                         <label for="sameAs_uri_{{ i }}" class="control-label col-xs-4" data-content="{{X.sameAsURI.tooltip}}" data-toggle="popover" data-placement="top">
                             {{ X.sameAsURI.display }}
@@ -486,7 +477,7 @@
                             {{ X.sameAsBaseURI.display }}
                         </label>
                         <div class="col-xs-8" id="select_sameAs_baseuri_{{i}}">
-                          <input id="sameAs_baseuri_id_{{i}}" name="sameAs_baseuri_id_{{i}}" type="hidden" class="form-control" value="{{ other.uri }}"/>
+                          <input id="sameAs_baseuri_id_{{i}}" name="sameAs_baseuri_id_{{i}}" type="hidden" class="form-control" value=""/>
                           <input id="sameAs_baseuri_term_{{i}}" name="sameAs_baseuri_term_{{i}}" type="hidden" class="form-control" value="{{ WorldCat }}"/>
                           <input id="sameAs_baseuri_vocabtype_{{i}}" name="sameAs_baseuri_vocabtype_{{i}}" type="hidden" class="form-control" value="external_sameas_domain"/>
                           <input id="sameAs_baseuri_minlength_{{i}}" name="sameAs_baseuri_minlength_{{i}}" type="hidden" class="form-control" value="0"/>
@@ -498,7 +489,7 @@
                             {{ X.sameAsURIId.display }}
                         </label>
                         <div class="col-xs-8" id="text_sameAs_uriid_{{i}}">
-                            <input id="sameAs_uriid_{{i}}" name="sameAs_uriid_{{i}}" type="hidden" class="form-control" value="{{ other.uri }}"/>
+                            <input id="sameAs_uriid_{{i}}" name="sameAs_uriid_{{i}}" type="hidden" class="form-control" value=""/>
                             <p class="form-control-static">{{ other.uri }}</p>
                         </div>
                     </div>

--- a/src/snac/client/webui/templates/edit_tabs/sameAs.html
+++ b/src/snac/client/webui/templates/edit_tabs/sameAs.html
@@ -2,7 +2,7 @@
 {% import 'edit_components.html' as components %}
 {% import 'date_entry.html' as dates %}
 
-<h2>External CPF Relations (Same As)</h2>
+<h2>External Related CPF</h2>
 
 <div class="form-group" id="add_sameAs_div">
     <div class="col-xs-12 text-center">

--- a/src/snac/client/webui/templates/maybesame_diff_page.html
+++ b/src/snac/client/webui/templates/maybesame_diff_page.html
@@ -475,7 +475,7 @@ $(document).ready(function() {
                                 {{sameasCount}}
                             </span>
                             {% endif %}
-                            <span class='component-title'>External CPF (Same As)</span></a>
+                            <span class='component-title'>External Related CPF</span></a>
                         <a class="list-group-item" href="#entityID" id="entityIDtab" role="tab" data-toggle="tab">
                             {% if (entityidCount) > 0 %}
                             <span class="badge">
@@ -962,7 +962,7 @@ $(document).ready(function() {
                                             </div>
                                             <script>
                                             pieceCache[{{i}}] = {
-                                                title: 'External CPF Relation (Same As)',
+                                                title: 'External Related CPF',
                                                 identifier: "#sameAs_datapart_{{i}}"
                                             };
                                             </script>
@@ -994,7 +994,7 @@ $(document).ready(function() {
                                             </div>
                                             <script>
                                             pieceCache[{{i}}] = {
-                                                title: 'External CPF Relation (Same As)',
+                                                title: 'External Related CPF',
                                                 identifier: "#sameAs_datapart_{{i}}"
                                             };
                                             </script>
@@ -1018,7 +1018,7 @@ $(document).ready(function() {
                                             </div>
                                             <script>
                                             pieceCache[{{i}}] = {
-                                                title: 'External CPF Relation (Same As)',
+                                                title: 'External Related CPF',
                                                 identifier: "#sameAs_datapart_{{i}}"
                                             };
                                             </script>

--- a/src/snac/client/webui/util/ConstellationPostMapper.php
+++ b/src/snac/client/webui/util/ConstellationPostMapper.php
@@ -1163,7 +1163,8 @@ class ConstellationPostMapper {
             }
             $sameas->setOperation($this->getOperation($data));
 
-            $sameas->setText($data["text"]);
+            if (isset($data["text"])) { $sameas->setText($data["text"]); }
+
             $sameas->setURI($data["uri"]);
 
             $sameas->setType($this->parseTerm($data["type"]));

--- a/src/virtualhosts/www/javascript/edit_scripts.js
+++ b/src/virtualhosts/www/javascript/edit_scripts.js
@@ -243,17 +243,35 @@ function textToSelect(shortName, idStr) {
                 scm_source_select_replace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr);
             else if (shortName == "sameAs" && name == "baseuri") {
                 //The following block handles the specific case of Same As External Resource association form
-                loadVocabSelectOptions($("#"+shortName+"_"+name+"_id_"+idStr), "external_sameas_domain", "Base URI", true);
-                var currentURI = $("#"+shortName+"_uri_"+idStr).val();
-                if (currentURI) {
-                    var authorityBaseURI = currentURI.slice(0, currentURI.lastIndexOf('/') + 1)
-                    var authorityID = currentURI.slice(currentURI.lastIndexOf('/') + 1)
-                    $("#sameAs_baseuri_id_"+idStr).val(authorityBaseURI);
-                    $("#sameAs_uriid_"+idStr).val(authorityID);
-                }
-                $("#"+shortName+"_uri_"+idStr).prop("readonly", true);
-            }
-            else
+                var loadPromise = loadVocabSelectOptions($("#"+shortName+"_"+name+"_id_"+idStr), "external_sameas_domain", "Base URI", true);
+                loadPromise.then(function(result){
+                    var currentURI = $("#"+shortName+"_uri_"+idStr).val();
+                    if (currentURI) {
+                        var found = false;
+                        $("#"+shortName+"_"+name+"_id_"+idStr+" option").each(function(index,op){
+                            if( found || (!op.hasAttribute("value") || !op.value)) {
+                                return;
+                            }
+                            var uriComponents = op.value.split(/{id}/);
+                            if(currentURI.indexOf(uriComponents[0]) == 0) {
+                                var currOption = op.value;
+                                var currId = currentURI.replace(uriComponents[0],"");
+                                if(!!uriComponents[1]) {
+                                    if(currentURI.indexOf(uriComponents[1]) != -1) {
+                                        currId = currId.replace(/uriComponents[1]$/,"");
+                                    }
+                                }
+                                found = true;
+                                $("#sameAs_baseuri_id_"+idStr).val(currOption);
+                                $("#sameAs_baseuri_id_"+idStr).trigger("change");
+                                $("#sameAs_uriid_"+idStr).val(currId);
+                                $("#sameAs_uri_"+idStr).val(currOption.replace(/{id}/,currId));
+                            }
+                        });
+                    }
+                    $("#"+shortName+"_uri_"+idStr).prop("readonly", true);
+                });
+            } else
                 vocab_select_replace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr, vocabtype, minlength);
 
         }

--- a/src/virtualhosts/www/javascript/select_loaders.js
+++ b/src/virtualhosts/www/javascript/select_loaders.js
@@ -284,36 +284,50 @@ function select_replace_simple(selectItem) {
  * @param  string [useDescription=false] Use description instead of value for text field on return object
  */
 function loadVocabSelectOptions(selectItem, type, placeholder, useDescription = false) {
+    var loadPromise = new Promise(function(resolve, reject){
+
     var url = "/vocabulary?type=" + type;
     if (useDescription == true) {
      url = url.concat("&use_description=true");
     }
     return $.get(snacUrl + url)
     .done(function(data) {
-        var options = data.results;
-        if (useDescription == true) {
-          options = options.reduce(function(newOptions, option){
-            var newElement = option;
-            newElement["id"] = option["value"]
-            newOptions.push(newElement);
-            return newOptions;
-          },[]);
-        }
-        selectItem.select2({
-            data: options,
-            allowClear: false,
-            theme: 'bootstrap',
-            placeholder: placeholder
+            var options = data.results;
+            if (useDescription == true) {
+              options = options.reduce(function(newOptions, option){
+                var newElement = option;
+                newElement["id"] = option["value"]
+                newOptions.push(newElement);
+                return newOptions;
+              },[]);
+            }
+            options.sort(function(a,b) {
+                if(a["text"] < b["text"]){
+                    return -1;
+                }
+                if(a["text"] > b["text"]){
+                    return 1;
+                }
+                return 0;
+            });
+            selectItem.select2({
+                data: options,
+                allowClear: false,
+                theme: 'bootstrap',
+                placeholder: placeholder
+            });
+            resolve("loaded");
         });
     });
+    return loadPromise;
 }
 
 function updateSameAsURI() {
     var id = this.id;
-    var sequence = id.slice(id.lastIndexOf('_') + 1)
+    var sequence = id.match(/_([0-9]+)$/)[1];
     var baseURI = $("#sameAs_baseuri_id_"+sequence).val();
     var uriId = $("#sameAs_uriid_"+sequence).val();
-    $("#sameAs_uri_"+sequence).val(baseURI+uriId);
+    $("#sameAs_uri_"+sequence).val(baseURI.replace(/{id}/,uriId));
 }
 
 /**


### PR DESCRIPTION
Updates same as changes and support for domain description via regex

Implemented changes requested to the Same As user interface. Details
to the changes requested can be found on issue https://github.com/snac-cooperative/snac/issues/256.

Implemented support for regular expression when defining a Same As
domain. Due to the extraction and matching of the regular expression the
code had to be modified to use Promises in order to be able to wait for
the Domain options obtained via an API. After the select has all the
options we are able to parse the current value to extract the ID using
the regular expression that defines the domain.
