### PR TITLE
Removes send to review pool from editorial interface

### DIFF
--- a/src/snac/client/webui/templates/_send_review_pane.html
+++ b/src/snac/client/webui/templates/_send_review_pane.html
@@ -11,7 +11,7 @@
                                 <textarea id="sendReviewMessage" class='panel panel-default panel-body' style='width: 100%' placeholder="You may write a message to the reviewer here..."></textarea>
                             </div>
                             <p>Search for a User's name or primary email address below to send this constellation to that person
-                            for review.  Alternatively, you may send it for review to the general reviewer pool.</p>
+                            for review.</p>
                             <div style="margin-top: 20px;">
                                 <select class="form-control" id="reviewersearchbox">
                                     <option></option>
@@ -21,7 +21,6 @@
                             <div id="user-results-box">
                             </div>
                             <div style="text-align: center; margin-top: 10px;">
-                                <button type="button" class="btn btn-default" id="save_and_review_general" data-dismiss="modal">Send to General Reviewer Pool</button>
                                 <button type="button" class="btn btn-success" id="save_and_review_touser" data-dismiss="modal">Send Review</button>
                             </div>
                         </div>


### PR DESCRIPTION
The button "Send to General Reviewer Pool" located in the editorial
interface was causing confusion. So it was requested to be removed, more
details on https://github.com/snac-cooperative/snac/issues/256.