### PR TITLE
Update for ElasticSearch 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
+	"config": {
+	"secure-http":false
+	},
     "require": {
         "php": "~7.0",
         "twig/twig": "~1.23",
         "monolog/monolog": "^1.18",
-        "elasticsearch/elasticsearch": "~2.0@beta",
+        "elasticsearch/elasticsearch": "*",
         "phpmailer/phpmailer": "~5.2",
         "snac/ark-manager": "*",
         "snac/eac-validator": "*",

--- a/scripts/rebuild_elastic.php
+++ b/scripts/rebuild_elastic.php
@@ -455,7 +455,7 @@ function indexSecondary($nameText, $ark, $icid, $nameid, $entityType, $degree, $
         // do one first to get the index going
         if (!$secondaryStart) {
             $params = [
-                    'index' => \snac\Config::$ELASTIC_SEARCH_BASE_INDEX,
+                    'index' => \snac\Config::$ELASTIC_SEARCH_ALL_INDEX,
                     'type' => \snac\Config::$ELASTIC_SEARCH_ALL_TYPE,
                     'id' => $nameid,
                     'body' => [
@@ -480,7 +480,7 @@ function indexSecondary($nameText, $ark, $icid, $nameid, $entityType, $degree, $
             // elasticsearch api = array with "index" => array(information), followed by array of data, then repeated
             $secondaryBody['body'][] = [
                 'index' => [
-                    '_index' => \snac\Config::$ELASTIC_SEARCH_BASE_INDEX,
+                    '_index' => \snac\Config::$ELASTIC_SEARCH_ALL_INDEX,
                     '_type' => \snac\Config::$ELASTIC_SEARCH_ALL_TYPE,
                     '_id' => $nameid
                 ]

--- a/src/snac/Config_dist.php
+++ b/src/snac/Config_dist.php
@@ -227,6 +227,11 @@ class Config {
     public static $ELASTIC_SEARCH_BASE_TYPE = "";
 
     /**
+     * @var string All index for the all name (and alternate) search functionality of snac
+     */
+    public static $ELASTIC_SEARCH_ALL_INDEX = "";
+
+    /**
      * @var string Search base for ALL of the snac name entries (and alternates)
      */
     public static $ELASTIC_SEARCH_ALL_TYPE = "";

--- a/src/snac/server/elastic/ElasticSearchUtil.php
+++ b/src/snac/server/elastic/ElasticSearchUtil.php
@@ -115,7 +115,7 @@ class ElasticSearchUtil {
             $this->connector->index($params);
             foreach ($constellation->getNameEntries() as $entry) {
                 $params = [
-                    'index' => \snac\Config::$ELASTIC_SEARCH_BASE_INDEX,
+                    'index' => \snac\Config::$ELASTIC_SEARCH_ALL_INDEX,
                     'type' => \snac\Config::$ELASTIC_SEARCH_ALL_TYPE,
                     'id' => $entry->getID(),
                     'body' => [
@@ -157,7 +157,7 @@ class ElasticSearchUtil {
             }
             foreach ($constellation->getNameEntries() as $entry) {
                 $params = [
-                    'index' => \snac\Config::$ELASTIC_SEARCH_BASE_INDEX,
+                    'index' => \snac\Config::$ELASTIC_SEARCH_ALL_INDEX,
                     'type' => \snac\Config::$ELASTIC_SEARCH_ALL_TYPE,
                     'id' => $entry->getID()
                 ];
@@ -678,7 +678,7 @@ class ElasticSearchUtil {
             }
 
             $response = array();
-            $response["total"] = $results["hits"]["total"];
+            $response["total"] = $results["hits"]["total"]["value"];
             $response["results"] = $return;
             $response["aggregations"] = $aggregations;
 


### PR DESCRIPTION
Elastic Search no longer allows a second type for an index, so we need
to split out the all names index from the normal search index.  This
commit separates them and brings the version of the elastic search
Composer library up to the current version.  However, it will require a
new configuration parameter and a refresh of the Elastic Search indices.