### PR TITLE
Openrefine updates - CPF reconciliation

### DIFF
--- a/src/snac/client/openrefine/ORConstellationMapper.php
+++ b/src/snac/client/openrefine/ORConstellationMapper.php
@@ -45,6 +45,16 @@ class ORConstellationMapper {
     ];
 
     /**
+     * @var array $types The types reconcilable by this OR endpoing
+     */
+    private $types = [
+        "constellation" => [
+            "id" => "CPF",
+            "name" => "Identity Constellation"
+        ]
+    ];
+
+    /**
      * @var array $vocabCache Cache of vocabulary terms searched
      * during this session
      */
@@ -162,6 +172,28 @@ class ORConstellationMapper {
         }
 
         return null;
+    }
+
+    /**
+     * Get the list of Reconciliation Types
+     *
+     * Returns the list of reconcilable types in SNAC
+     * @return array An array of types in OR format
+     */
+    public function getTypes() {
+        return array_values($this->types);
+    }
+
+    /**
+     * Look up type id by internal identifier
+     *
+     * Given the internal definition (i.e. constellation), return the OR-facing term (i.e. CPF)
+     *
+     * @param string $type The internal definition
+     * @return string The OR-facing term
+     */
+    public function lookupType($type) {
+        return $this->types[$type]["id"];
     }
 
 }

--- a/src/snac/client/openrefine/OpenRefine.php
+++ b/src/snac/client/openrefine/OpenRefine.php
@@ -152,7 +152,7 @@ class OpenRefine {
                         "name" => $result["identity"]["nameEntries"][0]["original"],
                         "id" => (string) $result["identity"]["id"],
                         "type" => [
-                            $result["identity"]["entityType"]["term"]
+                            $this->mapper->lookupType("constellation")
                         ],
                         "score" => round($result["strength"], 2),
                         "match" => ($result["strength"] > 11 ? true : false)
@@ -198,7 +198,9 @@ class OpenRefine {
                         $output = array(
                             "name" => $result["identity"]["nameEntries"][0]["original"],
                             "id" => (string) $result["identity"]["id"],
-                            "type" => [$result["identity"]["entityType"]["term"]],
+                            "type" => [
+                                $this->mapper->lookupType("constellation")
+                            ],
                             "score" => round($result["strength"], 2),
                             "match" => ($result["strength"] > 11 ? true : false)
                         );
@@ -215,12 +217,7 @@ class OpenRefine {
         } else {
             // Default response: give information about this OpenRefine endpoint
             $response = [
-                "defaultTypes" => [
-                    [
-                        "id" => "cpf",
-                        "name" => "Identity Constellation"
-                    ]
-                ],
+                "defaultTypes" => $this->mapper->getTypes(),
                 "view" => [
                     "url" => \snac\Config::$WEBUI_URL . "/view/{{id}}"
                 ],


### PR DESCRIPTION
Updated the types of reconciled objects to always be CPF.  This way, the end point is consistent when reconciling types.