### PR TITLE
Overwrite Resource display_entry on title edit

### DIFF
--- a/src/snac/server/ServerExecutor.php
+++ b/src/snac/server/ServerExecutor.php
@@ -1576,6 +1576,9 @@ class ServerExecutor {
                 $resource->setID((string) $resource->getID());
                 $resource->setVersion((string) $resource->getVersion());
 
+                // Overwrite displayEntry on title updates
+                $resource->setDisplayEntry($resource->getTitle());
+
                 $result = $this->cStore->writeResource($this->user, $resource);
                 if (isset($result) && $result != false) {
                     $this->elasticSearch->writeToResourceIndices($resource);


### PR DESCRIPTION
- When a Resource's title is updated, copy it over to the display_entry as well.
- Eventually display_entry will be phased out once high quality titles are ubiquitous.