### PR TITLE
Development

### DIFF
--- a/src/snac/Config_dist.php
+++ b/src/snac/Config_dist.php
@@ -69,6 +69,11 @@ class Config {
     public static $USE_LARAVEL_AUTHENTICATION = true;
 
     /**
+     * @var string SNAC Laravel base url
+     */
+    public static $LARAVEL_URL = 'http://localhost:8000';
+
+    /**
      * @var boolean Whether the system in OFFLINE (Maintenance) mode
      */
     public static $SITE_OFFLINE = false;

--- a/src/snac/client/webui/display/Display.php
+++ b/src/snac/client/webui/display/Display.php
@@ -175,6 +175,7 @@ class Display {
         $this->data["control"]["referringURL"] = $this->cleanString(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : "unknown");
         $this->data["control"]["snacURL"] = \snac\Config::$WEBUI_URL;
         $this->data["control"]["restURL"] = \snac\Config::$REST_URL;
+        $this->data["control"]["laravelURL"] = \snac\Config::$LARAVEL_URL;
         $this->data["control"]["redirectAfterLogin"] = \snac\Config::$REDIRECT_AFTER_LOGIN_URL;
         $this->data["control"]["redirectAfterLogout"] = \snac\Config::$REDIRECT_AFTER_LOGOUT_URL;
         $this->data["control"]["laravelLoginURL"] = \snac\Config::$LARAVEL_LOGIN_URL;

--- a/src/snac/client/webui/templates/page_navigation.html
+++ b/src/snac/client/webui/templates/page_navigation.html
@@ -16,6 +16,7 @@
     <script>
         var snacUrl = "{{control.snacURL}}";
         var restUrl = "{{control.restURL}}";
+        var laravelUrl = "{{control.laravelURL}}";
     </script>
 
     {% if control.interfaceVersion == "development" %}

--- a/src/snac/server/database/DBUtil.php
+++ b/src/snac/server/database/DBUtil.php
@@ -958,13 +958,14 @@ class DBUtil
         } elseif ($term->getTerm() && $term->getType()) {
             $termData = $this->sql->selectTermByValueAndType($term->getTerm(), $term->getType());
 
-            if (!$termData && $term->getType() && $term->getTerm()) {
-                $this->sql->insertVocabularyTerm($term->getType(),
-                    $term->getTerm(),
-                    null,
-                    "Auto-inserted term");
-                $termData = $this->sql->selectTermByValueAndType($term->getTerm(), $term->getType()); //
-            }
+            //   deprecated 2/2022 No longer allowing auto-inserts of terms anymore with ConceptVocab
+            // if (!$termData && $term->getType() && $term->getTerm()) {
+            //     $this->sql->insertVocabularyTerm($term->getType(),
+            //         $term->getTerm(),
+            //         null,
+            //         "Auto-inserted term");
+            //     $termData = $this->sql->selectTermByValueAndType($term->getTerm(), $term->getType()); //
+            // }
             $id = $termData['id'];
         } elseif ($term->getURI()) {
             $termData = $this->sql->selectTermByUri($term->getURI());

--- a/src/snac/server/database/DBUtil.php
+++ b/src/snac/server/database/DBUtil.php
@@ -1118,7 +1118,7 @@ class DBUtil
             $this->populateStructureOrGenealogy($vhInfo, $cObj);
             // populateConcepts
             $this->logger->addDebug("  Concepts");
-            $this->populateConceptTerms($vhInfo, $cObj);
+            $this->populateIdentityConceptTerms($vhInfo, $cObj);
             // Deprecated 2/2022
             // $this->logger->addDebug("  Subject");
             // $this->populateSubject($vhInfo, $cObj);
@@ -3296,7 +3296,7 @@ class DBUtil
      * @param $cObj \snac\data\Constellation object, passed by reference, and changed in place
      *
      */
-    private function populateConceptTerms($vhInfo, $cObj)
+    private function populateIdentityConceptTerms($vhInfo, $cObj)
     {
         $conceptRows = $this->sql->selectIdentityConceptTerms($vhInfo);
 

--- a/src/snac/server/database/DBUtil.php
+++ b/src/snac/server/database/DBUtil.php
@@ -1747,6 +1747,41 @@ class DBUtil
     }
 
     /**
+     * Populate Concept Term
+     *
+     * Temporary function to handle SNAC access of individual Concept System Terms.
+     * Will be replaced with a call to SNAC-Laravel
+     *
+     * @param string $value optional The value of a vocabulary term
+     *
+     * @param string $type optional The type of a vocabulary term
+     *
+     * @return \snac\data\Term The populated term object
+     *
+     */
+    public function populateConceptTerm($value=null, $type=null)
+    {
+
+        if (isset($value) && isset($type)) {
+            $row = $this->sql->selectConceptTermByValue($value,$type);
+        }
+
+        if (!isset($row) || empty($row))
+            return null;
+
+        if ($row['term_id'] == null)
+            return null;
+
+        $newObj = new \snac\data\Term();
+
+        $newObj->setID($row['concept_id']);
+        $newObj->setTerm($row['text']);
+        $newObj->setType($row['type']);
+
+        return $newObj;
+    }
+
+    /**
      * Build the Term Cache
      *
      * This function builds an entire copy of the term cache in memory.  It is too big to fit in memory, and therefore should

--- a/src/snac/util/EACCPFParser.php
+++ b/src/snac/util/EACCPFParser.php
@@ -179,8 +179,16 @@ class EACCPFParser {
             }
         }
 
-
         $term = null;
+        
+        // Concept Vocab
+        if ($vocab == "occupation" || $vocab == "subject" ||  $vocab == "activity") {
+            $term = $this->vocabulary->getConceptTermByValue($fixed, $vocab);
+            if ($term === null)
+                $this->logger->warn("Could not find term for $vocab: $fixed");
+            return $term;
+        }
+
         if ($this->vocabulary != null) {
             $term = $this->vocabulary->getTermByValue($fixed, $vocab);
         } else {
@@ -964,27 +972,28 @@ class EACCPFParser {
                                     switch ($occ->getName()) {
                                     case "term":
                                         $occupation->setTerm($this->getTerm((string) $occ, "occupation"));
-                                        if (isset($oatts["vocabularySource"])) {
-                                            $occupation->setVocabularySource($oatts["vocabularySource"]);
-                                            unset($oatts["vocabularySource"]);
-                                        }
-                                        break;
-                                    case "descriptiveNote":
-                                        $occupation->setNote((string) $occ);
-                                        break;
-                                    case "dateRange":
-                                        $date = $this->parseDate($occ,
-                                                                 array (
-                                                                     $node->getName(),
-                                                                     $desc->getName(),
-                                                                     $desc2->getName()
-                                                                 ));
-                                        /*
-                                         * Occupation extends AbstractData which has a date list.
-                                         *
-                                         * change setDateRange() to addDate()
-                                         */
-                                        $occupation->addDate($date);
+                                    // deprecated 2/2022 for move to Concept vocab system.
+                                    //     if (isset($oatts["vocabularySource"])) {
+                                    //         $occupation->setVocabularySource($oatts["vocabularySource"]);
+                                    //         unset($oatts["vocabularySource"]);
+                                    //     }
+                                    //     break;
+                                    // case "descriptiveNote":
+                                    //     $occupation->setNote((string) $occ);
+                                    //     break;
+                                    // case "dateRange":
+                                    //     $date = $this->parseDate($occ,
+                                    //                              array (
+                                    //                                  $node->getName(),
+                                    //                                  $desc->getName(),
+                                    //                                  $desc2->getName()
+                                    //                              ));
+                                    //     /*
+                                    //      * Occupation extends AbstractData which has a date list.
+                                    //      *
+                                    //      * change setDateRange() to addDate()
+                                    //      */
+                                    //     $occupation->addDate($date);
                                         break;
                                     default:
                                         $this->markUnknownTag(

--- a/src/snac/util/LocalVocabulary.php
+++ b/src/snac/util/LocalVocabulary.php
@@ -17,7 +17,7 @@ namespace snac\util;
  * seaching for a Term object from a string of the term or ID.
  *
  * @author Robbie Hott
- *        
+ *
  */
 class LocalVocabulary implements \snac\util\Vocabulary {
 
@@ -25,7 +25,7 @@ class LocalVocabulary implements \snac\util\Vocabulary {
      * @var string[][] The vocabulary array, preloaded in the constructor
      */
     private $vocab = null;
-    
+
     /**
      * @var \snac\server\database\DBUtil database utility handle
      */
@@ -88,7 +88,19 @@ class LocalVocabulary implements \snac\util\Vocabulary {
     }
 
     /**
-     * Get a Term by integer id 
+     * Get a Concept Term by string value/term
+     *
+     * @param string $value The value of the term to search for
+     * @param string $type The type of controlled vocab
+     * @return \snac\data\Term The Term object for the value
+     */
+    public function getConceptTermByValue($value, $type) {
+        $this->setupConstellationStore();
+        return $this->db->populateConceptTerm($value, $type);
+    }
+
+    /**
+     * Get a Term by integer id
      *
      * @param string $id The persistent ID (int) for the term
      * @param string $type The type of controlled vocab
@@ -98,7 +110,7 @@ class LocalVocabulary implements \snac\util\Vocabulary {
         $this->setupConstellationStore();
         return $this->db->populateTerm($id);
     }
-    
+
 
     /**
      * Get a GeoTerm by URI

--- a/src/virtualhosts/www/javascript/edit_scripts.js
+++ b/src/virtualhosts/www/javascript/edit_scripts.js
@@ -271,6 +271,9 @@ function textToSelect(shortName, idStr) {
                     }
                     $("#"+shortName+"_uri_"+idStr).prop("readonly", true);
                 });
+                // If dealing with subject, function, or occupation term, query Concept Vocab system
+            } else if (shortName == 'activity' || shortName == 'subject' || shortName =='occupation') {
+                conceptVocabSelectReplace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr, vocabtype, minlength);
             } else
                 vocab_select_replace($("#"+shortName+"_"+name+"_id_"+idStr), "_"+idStr, vocabtype, minlength);
 

--- a/src/virtualhosts/www/javascript/select_loaders.js
+++ b/src/virtualhosts/www/javascript/select_loaders.js
@@ -57,6 +57,49 @@ function vocab_select_replace(selectItem, idMatch, type, minLength) {
             }
 }
 
+/**
+ * Replace a select that is linked to a ConceptVocabulary search
+ *
+ * Replaces the select with a select2 object capable of making AJAX queries
+ *
+ * @param  JQuery selectItem The JQuery item to replace
+ * @param  string idMatch    ID string for the object on the page
+ * @param  string type       The type of the vocabulary term
+ * @param  int    minLength  The minimum required length of the autocomplete search
+ */
+function conceptVocabSelectReplace(selectItem, idMatch, type, minLength) {
+    if (minLength === undefined) {
+        minLength = 2;
+    }
+
+    if(selectItem.attr('id').endsWith(idMatch)
+        && !selectItem.attr('id').endsWith("ZZ")) {
+            selectItem.select2({
+                ajax: {
+                    url: laravelUrl+'/concepts/search',
+                    dataType: 'json',
+                    delay: 250,
+                    data: function (params) {
+                        return {
+                            term: params.term,
+                            category: type,
+                            page: params.page
+                        };
+                    },
+                    processResults: function (data, page) {
+                        return { results: data.map(function(concept) { return { id: concept.concept_id, text: concept.text}})  };
+                    },
+                    cache: true
+                },
+                width: '100%',
+                minimumInputLength: minLength,
+                allowClear: true,
+                theme: 'bootstrap',
+                placeholder: 'Select'
+            });
+        }
+}
+
 var geoPlaceSearchResults = null;
 
 function geovocab_select_replace(selectItem, idMatch) {
@@ -345,17 +388,18 @@ $(document).ready(function() {
             // Replace the subject selects
             vocab_select_replace($(this), "language_script_", "script_code", 1);
 
-            // Replace the subject selects
-            vocab_select_replace($(this), "subject_", "subject", 4);
-
-            // Replace the activity selects
-            vocab_select_replace($(this), "activity_", "activity", 4);
-
-            // Replace the occupation selects
-            vocab_select_replace($(this), "occupation_", "occupation", 4);
-
             // Replace the entityType select
             vocab_select_replace($(this), "entityType", "entity_type", 0);
+
+            // Replace the subject selects
+            conceptVocabSelectReplace($(this), "subject_", "subject", 4);
+
+            // Replace the activity selects
+            conceptVocabSelectReplace($(this), "activity_", "activity", 4);
+
+            // Replace the occupation selects
+            conceptVocabSelectReplace($(this), "occupation_", "occupation", 4);
+
         }
     });
 

--- a/test/snac/server/database/test_record.xml
+++ b/test/snac/server/database/test_record.xml
@@ -53,7 +53,7 @@
                 <objectXMLWrap>
                     <container xmlns="">
                         <filename>/data/source/findingAids/lc/ms009141.xml</filename>
-                        <ead_entity altrender=":::PWEBRECON=^Jefferson%2C+Thomas%2C+1743-1826+Correspondence.^" en_type="persname" encodinganalog="600" role="subject" source="lcnaf">Jefferson, Thomas, 1743-1826--Correspondence.</ead_entity>
+                        <ead_entity altrender=":::PWEBRECON=^Jefferson%2C+Thomas%2C+1743-1826+Correspondence.^" en_type="persname" encodinganalog="600" role="subject" source="lcnaf">Jefferson, Thomas, 1743-1826</ead_entity>
                     </container>
                 </objectXMLWrap>
             </source>
@@ -196,10 +196,10 @@
                 <placeEntry countryCode="US"/>
             </localDescription>
             <occupation>
-                <term>Inventors.</term>
+                <term>Inventors</term>
             </occupation>
             <occupation>
-                <term>Philosophers.</term>
+                <term>Philosophers</term>
             </occupation>
             <generalContext>
                 <p>Sample GC</p>


### PR DESCRIPTION
- Migrates SNAC to the Concept Vocabulary system for Subjects, Activities, and Occupations. 
- Switches populating Subjects, Activities, and Occupations records from their tables to a single `identity_concepts` table, while their terms are pulled from `terms` and `concepts` table instead of the `vocabulary` table.
- We continue using `vocabulary` table for other controlled terms and keywords for the internal system.